### PR TITLE
feat : 온보딩 다중 역할(BOTH),클라프리 지원 및 통합 처리 로직 구현

### DIFF
--- a/backend/src/main/java/com/devnear/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/devnear/global/config/DataInitializer.java
@@ -1,0 +1,38 @@
+package com.devnear.global.config;
+
+import com.devnear.web.domain.skill.Skill;
+import com.devnear.web.domain.skill.SkillRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final SkillRepository skillRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // [추가] 서버 시작 시 스킬 테이블이 비어 있다면 기본 스킬을 자동으로 채워줌
+        // 프론트엔드 온보딩 테스트에서 '존재하지 않는 스킬' 에러를 막기 위한 조치
+        if (skillRepository.count() == 0) {
+            List<Skill> defaultSkills = List.of(
+                    Skill.builder().name("Java").isDefault(true).category("Backend").build(),
+                    Skill.builder().name("Spring Boot").isDefault(true).category("Backend").build(),
+                    Skill.builder().name("React").isDefault(true).category("Frontend").build(),
+                    Skill.builder().name("Next.js").isDefault(true).category("Frontend").build(),
+                    Skill.builder().name("TypeScript").isDefault(true).category("Frontend").build(),
+                    Skill.builder().name("Node.js").isDefault(true).category("Backend").build(),
+                    Skill.builder().name("Figma").isDefault(true).category("Design").build(),
+                    Skill.builder().name("Python").isDefault(true).category("Backend").build(),
+                    Skill.builder().name("AWS").isDefault(true).category("DevOps").build(),
+                    Skill.builder().name("Docker").isDefault(true).category("DevOps").build()
+            );
+            skillRepository.saveAll(defaultSkills);
+            System.out.println("========== [DataInitializer] 기본 스킬 10개가 성공적으로 생성되었습니다! ==========");
+        }
+    }
+}

--- a/backend/src/main/java/com/devnear/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/devnear/global/config/DataInitializer.java
@@ -16,23 +16,30 @@ public class DataInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        // [추가] 서버 시작 시 스킬 테이블이 비어 있다면 기본 스킬을 자동으로 채워줌
-        // 프론트엔드 온보딩 테스트에서 '존재하지 않는 스킬' 에러를 막기 위한 조치
-        if (skillRepository.count() == 0) {
-            List<Skill> defaultSkills = List.of(
-                    Skill.builder().name("Java").isDefault(true).category("Backend").build(),
-                    Skill.builder().name("Spring Boot").isDefault(true).category("Backend").build(),
-                    Skill.builder().name("React").isDefault(true).category("Frontend").build(),
-                    Skill.builder().name("Next.js").isDefault(true).category("Frontend").build(),
-                    Skill.builder().name("TypeScript").isDefault(true).category("Frontend").build(),
-                    Skill.builder().name("Node.js").isDefault(true).category("Backend").build(),
-                    Skill.builder().name("Figma").isDefault(true).category("Design").build(),
-                    Skill.builder().name("Python").isDefault(true).category("Backend").build(),
-                    Skill.builder().name("AWS").isDefault(true).category("DevOps").build(),
-                    Skill.builder().name("Docker").isDefault(true).category("DevOps").build()
-            );
-            skillRepository.saveAll(defaultSkills);
-            System.out.println("========== [DataInitializer] 기본 스킬 10개가 성공적으로 생성되었습니다! ==========");
+        // [수정] 리뷰 반영: count() == 0 체크 대신, 개별 스킬 이름을 확인하여 없는 스킬만 추가하는 방식으로 무결성 강화
+        List<Skill> defaultSkills = List.of(
+                Skill.builder().name("Java").isDefault(true).category("Backend").build(),
+                Skill.builder().name("Spring Boot").isDefault(true).category("Backend").build(),
+                Skill.builder().name("React").isDefault(true).category("Frontend").build(),
+                Skill.builder().name("Next.js").isDefault(true).category("Frontend").build(),
+                Skill.builder().name("TypeScript").isDefault(true).category("Frontend").build(),
+                Skill.builder().name("Node.js").isDefault(true).category("Backend").build(),
+                Skill.builder().name("Figma").isDefault(true).category("Design").build(),
+                Skill.builder().name("Python").isDefault(true).category("Backend").build(),
+                Skill.builder().name("AWS").isDefault(true).category("DevOps").build(),
+                Skill.builder().name("Docker").isDefault(true).category("DevOps").build()
+        );
+
+        int addedCount = 0;
+        for (Skill skill : defaultSkills) {
+            if (!skillRepository.existsByName(skill.getName())) {
+                skillRepository.save(skill);
+                addedCount++;
+            }
+        }
+
+        if (addedCount > 0) {
+            System.out.println("========== [DataInitializer] 기본 스킬 " + addedCount + "개가 새롭게 추가되었습니다! ==========");
         }
     }
 }

--- a/backend/src/main/java/com/devnear/web/controller/user/UserController.java
+++ b/backend/src/main/java/com/devnear/web/controller/user/UserController.java
@@ -6,6 +6,7 @@ import com.devnear.web.dto.user.UserInfoResponse;
 import com.devnear.web.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,7 +29,7 @@ public class UserController {
     @PostMapping("/onboarding")
     public ResponseEntity<TokenResponse> onboarding(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody OnboardingRequest request) {
+            @RequestBody @Valid OnboardingRequest request) {
         
         // [보고] UserService를 통해 DB 업데이트 및 새 JWT 토큰(권한 승격됨)을 발급받아 반환합니다.
         TokenResponse response = userService.onboarding(userDetails.getUsername(), request);

--- a/backend/src/main/java/com/devnear/web/domain/user/User.java
+++ b/backend/src/main/java/com/devnear/web/domain/user/User.java
@@ -3,6 +3,8 @@ package com.devnear.web.domain.user;
 import com.devnear.web.domain.common.BaseTimeEntity;
 import com.devnear.web.domain.enums.Role;
 import com.devnear.web.domain.enums.UserStatus;
+import com.devnear.web.domain.client.ClientProfile; // [추가] 패키지 경로 확인 필요
+import com.devnear.web.domain.freelancer.FreelancerProfile; // [추가] 패키지 경로 확인 필요
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +23,7 @@ import java.util.List;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_provider_id",
-                        columnNames = {"provider", "provider_id"} // provider와 provider_id의 쌍은 유일해야 함
+                        columnNames = {"provider", "provider_id"}
                 )
         }
 )
@@ -37,14 +39,12 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    // [보고] 소셜 로그인은 비번이 없으므로 nullable = true
     @Column(nullable = true)
     private String password;
 
     @Column(nullable = false, length = 50)
     private String name;
 
-    // [수정] 항상 임시 닉네임을 생성해서 넣어주므로 nullable = false
     @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
@@ -62,12 +62,23 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false, length = 20)
     private UserStatus status;
 
-    // ================= [보고] 소셜 로그인 전용 필드 =================
     @Column(length = 20)
     private String provider;
 
     @Column(name = "provider_id", length = 100)
     private String providerId;
+
+    // ================= [추가] 영속성 전이(Cascade) 설정 =================
+
+    // [보고] 유저 삭제 시 클라이언트 프로필도 함께 삭제됩니다.
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ClientProfile clientProfile;
+
+    // [보고] 유저 삭제 시 프리랜서 프로필도 함께 삭제됩니다.
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private FreelancerProfile freelancerProfile;
+
+    // =================================================================
 
     @Builder
     public User(String email, String password, String name, String nickname,
@@ -85,9 +96,6 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.status = UserStatus.ACTIVE;
     }
 
-    /**
-     * [보고] 소셜 로그인 정보 업데이트 및 계정 연동을 위한 메서드.
-     */
     public User update(String name, String profileImageUrl, String provider, String providerId) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
@@ -96,15 +104,12 @@ public class User extends BaseTimeEntity implements UserDetails {
         return this;
     }
 
-    /**
-     * [추가] 온보딩 완료 시 닉네임과 역할을 업데이트합니다.
-     */
     public void onboard(String nickname, Role role) {
         this.nickname = nickname;
         this.role = role;
     }
 
-    // ================= UserDetails 필수 구현 메서드 =================
+    // UserDetails 메서드 생략 (기존과 동일)
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + this.role.name()));
@@ -112,22 +117,16 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Override
     public String getUsername() { return this.email; }
-
     @Override
     public String getPassword() { return this.password; }
-
     @Override
     public boolean isAccountNonExpired() { return true; }
-
     @Override
     public boolean isAccountNonLocked() { return true; }
-
     @Override
     public boolean isCredentialsNonExpired() { return true; }
-
     @Override
-    public boolean isEnabled() { 
-        // [수정] "화이트리스트" 방식으로 허용되는 상태만 명시함
+    public boolean isEnabled() {
         return this.status == UserStatus.ACTIVE || this.status == UserStatus.INACTIVE;
     }
 }

--- a/backend/src/main/java/com/devnear/web/domain/user/User.java
+++ b/backend/src/main/java/com/devnear/web/domain/user/User.java
@@ -3,8 +3,6 @@ package com.devnear.web.domain.user;
 import com.devnear.web.domain.common.BaseTimeEntity;
 import com.devnear.web.domain.enums.Role;
 import com.devnear.web.domain.enums.UserStatus;
-import com.devnear.web.domain.client.ClientProfile; // [추가] 패키지 경로 확인 필요
-import com.devnear.web.domain.freelancer.FreelancerProfile; // [추가] 패키지 경로 확인 필요
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,6 +11,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import com.devnear.web.domain.client.ClientProfile;
+import com.devnear.web.domain.freelancer.FreelancerProfile;
 
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_provider_id",
-                        columnNames = {"provider", "provider_id"}
+                        columnNames = {"provider", "provider_id"} // provider와 provider_id의 쌍은 유일해야 함
                 )
         }
 )
@@ -39,12 +39,14 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
+    // [보고] 소셜 로그인은 비번이 없으므로 nullable = true
     @Column(nullable = true)
     private String password;
 
     @Column(nullable = false, length = 50)
     private String name;
 
+    // [수정] 항상 임시 닉네임을 생성해서 넣어주므로 nullable = false
     @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
@@ -62,23 +64,20 @@ public class User extends BaseTimeEntity implements UserDetails {
     @Column(nullable = false, length = 20)
     private UserStatus status;
 
+    // ================= [보고] 소셜 로그인 전용 필드 =================
     @Column(length = 20)
     private String provider;
 
     @Column(name = "provider_id", length = 100)
     private String providerId;
 
-    // ================= [추가] 영속성 전이(Cascade) 설정 =================
-
-    // [보고] 유저 삭제 시 클라이언트 프로필도 함께 삭제됩니다.
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    // [수정] 리뷰 피드백 반영: @OneToOne의 기본 로딩은 Eager(즉시 로딩)이므로 N+1 및 성능 이슈 방지를 위해 LAZY로 강제 지정
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private ClientProfile clientProfile;
 
-    // [보고] 유저 삭제 시 프리랜서 프로필도 함께 삭제됩니다.
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    // [수정] 리뷰 피드백 반영: 동일하게 성능 이슈 방지를 위해 LAZY 로딩 적용
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private FreelancerProfile freelancerProfile;
-
-    // =================================================================
 
     @Builder
     public User(String email, String password, String name, String nickname,
@@ -96,6 +95,9 @@ public class User extends BaseTimeEntity implements UserDetails {
         this.status = UserStatus.ACTIVE;
     }
 
+    /**
+     * [보고] 소셜 로그인 정보 업데이트 및 계정 연동을 위한 메서드.
+     */
     public User update(String name, String profileImageUrl, String provider, String providerId) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
@@ -104,12 +106,15 @@ public class User extends BaseTimeEntity implements UserDetails {
         return this;
     }
 
+    /**
+     * [추가] 온보딩 완료 시 닉네임과 역할을 업데이트합니다.
+     */
     public void onboard(String nickname, Role role) {
         this.nickname = nickname;
         this.role = role;
     }
 
-    // UserDetails 메서드 생략 (기존과 동일)
+    // ================= UserDetails 필수 구현 메서드 =================
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + this.role.name()));
@@ -117,16 +122,22 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Override
     public String getUsername() { return this.email; }
+
     @Override
     public String getPassword() { return this.password; }
+
     @Override
     public boolean isAccountNonExpired() { return true; }
+
     @Override
     public boolean isAccountNonLocked() { return true; }
+
     @Override
     public boolean isCredentialsNonExpired() { return true; }
+
     @Override
-    public boolean isEnabled() {
-        return this.status == UserStatus.ACTIVE || this.status == UserStatus.INACTIVE;
+    public boolean isEnabled() { 
+        // [수정] "화이트리스트" 방식으로 허용되는 상태만 명시함
+        return this.status == UserStatus.ACTIVE || this.status == UserStatus.INACTIVE; 
     }
 }

--- a/backend/src/main/java/com/devnear/web/dto/user/OnboardingRequest.java
+++ b/backend/src/main/java/com/devnear/web/dto/user/OnboardingRequest.java
@@ -1,6 +1,9 @@
 package com.devnear.web.dto.user;
 
 import com.devnear.web.domain.enums.Role;
+import com.devnear.web.dto.client.ClientProfileRequest;
+import com.devnear.web.dto.freelancer.FreelancerProfileRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -9,7 +12,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-
 public class OnboardingRequest {
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(max = 20, message = "닉네임은 20자 이내여야 합니다.")
@@ -17,4 +19,12 @@ public class OnboardingRequest {
 
     @NotNull(message = "역할 선택은 필수입니다.")
     private Role role;
+
+    // [보고] 역할이 CLIENT나 BOTH일 경우 필수입니다.
+    @Valid
+    private ClientProfileRequest clientProfile;
+
+    // [보고] 역할이 FREELANCER나 BOTH일 경우 필수입니다.
+    @Valid
+    private FreelancerProfileRequest freelancerProfile;
 }

--- a/backend/src/main/java/com/devnear/web/dto/user/UserRegisterRequest.java
+++ b/backend/src/main/java/com/devnear/web/dto/user/UserRegisterRequest.java
@@ -15,12 +15,18 @@ public class UserRegisterRequest {
     private Role role;
 
     public User toEntity(String encodedPassword) {
+        // 닉네임이 없으면 이메일 앞부분을 임시로 사용
+        String finalNickname = (nickname == null || nickname.isBlank())
+                ? email.split("@")[0] + "_" + System.currentTimeMillis() % 1000
+                : nickname;
+            // 역할이 없으면 무조건 GUEST
+        Role finalRole = (role == null) ? Role.GUEST : role;
         return User.builder()
                 .email(email)
-                .password(encodedPassword) // 암호화된 비번 저장
+                .password(encodedPassword)
                 .name(name)
-                .nickname(nickname)
-                .role(role)
+                .nickname(finalNickname) // 임시 닉네임 주입
+                .role(finalRole)         // GUEST 역할 주입
                 .build();
     }
 }

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
         // 1. 유저 기본 정보 업데이트
         user.onboard(request.getNickname(), request.getRole());
 
-        // [보고] 500 에러 및 Null 방지를 위해 선택한 역할에 따른 프로필 데이터 누락 검증 (Fail-Fast)
+        // [보고] 500 에러 방지를 위해 필수 프로필 정보 누락 검증
         if ((request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) && request.getClientProfile() == null) {
             throw new IllegalArgumentException("클라이언트 프로필 정보가 누락되었습니다.");
         }
@@ -85,13 +85,22 @@ public class UserService {
 
         // 2. 클라이언트 프로필 저장 (CLIENT 또는 BOTH)
         if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
-            // [보고] 트랜잭션이 하나로 묶여있어 외래키 문제나 정합성 오류가 발생하지 않습니다.
-            clientProfileRepository.save(request.getClientProfile().toEntity(user));
+            // [보고] 리뷰 반영: 멱등성 보장 - 기존 프로필이 있으면 업데이트, 없으면 생성
+            clientProfileRepository.findByUser(user)
+                    .ifPresentOrElse(
+                            existingProfile -> existingProfile.update(request.getClientProfile()), // 이미 있으면 Update
+                            () -> clientProfileRepository.save(request.getClientProfile().toEntity(user)) // 없으면 Create
+                    );
         }
 
-        // 3. [추가] 프리랜서 프로필 저장 (FREELANCER 또는 BOTH)
+        // 3. 프리랜서 프로필 저장 (FREELANCER 또는 BOTH)
         if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
             FreelancerProfileRequest fReq = request.getFreelancerProfile();
+
+            // [보고] 리뷰 반영: 멱등성 보장 - 기존 프리랜서 프로필이 이미 있으면 에러 처리(혹은 Update)
+            if (freelancerProfileRepository.findByUser_Id(user.getId()).isPresent()) {
+                throw new IllegalStateException("이미 프리랜서 프로필이 존재합니다.");
+            }
 
             FreelancerProfile profile = FreelancerProfile.builder()
                     .user(user)

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -67,7 +68,8 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
 
-        if (!user.getNickname().equals(request.getNickname()) &&
+        // [보고] 리뷰 반영: NPE(NullPointerException) 방지를 위해 Objects.equals()로 안전하게 닉네임 변경 여부를 체크함
+        if (!Objects.equals(user.getNickname(), request.getNickname()) &&
                 userRepository.existsByNickname(request.getNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }

--- a/backend/src/main/java/com/devnear/web/service/user/UserService.java
+++ b/backend/src/main/java/com/devnear/web/service/user/UserService.java
@@ -1,8 +1,16 @@
 package com.devnear.web.service.user;
 
 import com.devnear.global.auth.JwtTokenProvider;
+import com.devnear.web.domain.client.ClientProfileRepository;
+import com.devnear.web.domain.enums.Role;
+import com.devnear.web.domain.freelancer.FreelancerProfile;
+import com.devnear.web.domain.freelancer.FreelancerProfileRepository;
+import com.devnear.web.domain.freelancer.FreelancerSkill;
+import com.devnear.web.domain.skill.Skill;
+import com.devnear.web.domain.skill.SkillRepository;
 import com.devnear.web.domain.user.User;
 import com.devnear.web.domain.user.UserRepository;
+import com.devnear.web.dto.freelancer.FreelancerProfileRequest;
 import com.devnear.web.dto.user.OnboardingRequest;
 import com.devnear.web.dto.user.TokenResponse;
 import com.devnear.web.dto.user.UserInfoResponse;
@@ -13,6 +21,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,23 +32,20 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ClientProfileRepository clientProfileRepository;
+    private final FreelancerProfileRepository freelancerProfileRepository;
+    private final SkillRepository skillRepository;
 
     @Transactional
     public Long register(UserRegisterRequest request) {
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
-
-        // 비밀번호 암호화 처리
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         User user = request.toEntity(encodedPassword);
-
         return userRepository.save(user).getId();
     }
 
-    /**
-     * 로그인 로직 (최종본: JWT 토큰 발급)
-     */
     @Transactional
     public TokenResponse login(UserLoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
@@ -47,36 +55,76 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 드디어 토큰 발행!
         String token = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());
         return new TokenResponse(token, "Bearer");
     }
 
     /**
-     * [추가] 온보딩 로직: 닉네임과 역할을 업데이트하고 새 토큰을 발급합니다.
+     * [최종 통합] 온보딩 로직: 닉네임/역할 업데이트 및 각 프로필 동시 저장
      */
     @Transactional
     public TokenResponse onboarding(String email, OnboardingRequest request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
 
-        // [보고] 닉네임 중복 검사 (본인의 기존 닉네임과 다를 경우만)
-        if (!user.getNickname().equals(request.getNickname()) && 
-            userRepository.existsByNickname(request.getNickname())) {
+        if (!user.getNickname().equals(request.getNickname()) &&
+                userRepository.existsByNickname(request.getNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        // [보고] 엔티티 업데이트 (더티 체킹으로 DB 자동 반영)
+        // 1. 유저 기본 정보 업데이트
         user.onboard(request.getNickname(), request.getRole());
 
-        // [보고] 권한이 승격(GUEST -> CLIENT 등)되었으므로 새 토큰 발급
+        // [보고] 500 에러 및 Null 방지를 위해 선택한 역할에 따른 프로필 데이터 누락 검증 (Fail-Fast)
+        if ((request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) && request.getClientProfile() == null) {
+            throw new IllegalArgumentException("클라이언트 프로필 정보가 누락되었습니다.");
+        }
+        if ((request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) && request.getFreelancerProfile() == null) {
+            throw new IllegalArgumentException("프리랜서 프로필 정보가 누락되었습니다.");
+        }
+
+        // 2. 클라이언트 프로필 저장 (CLIENT 또는 BOTH)
+        if (request.getRole() == Role.CLIENT || request.getRole() == Role.BOTH) {
+            // [보고] 트랜잭션이 하나로 묶여있어 외래키 문제나 정합성 오류가 발생하지 않습니다.
+            clientProfileRepository.save(request.getClientProfile().toEntity(user));
+        }
+
+        // 3. [추가] 프리랜서 프로필 저장 (FREELANCER 또는 BOTH)
+        if (request.getRole() == Role.FREELANCER || request.getRole() == Role.BOTH) {
+            FreelancerProfileRequest fReq = request.getFreelancerProfile();
+
+            FreelancerProfile profile = FreelancerProfile.builder()
+                    .user(user)
+                    .introduction(fReq.getIntroduction())
+                    .location(fReq.getLocation())
+                    .latitude(fReq.getLatitude())
+                    .longitude(fReq.getLongitude())
+                    .hourlyRate(fReq.getHourlyRate())
+                    .workStyle(fReq.getWorkStyle())
+                    .isActive(true)
+                    .build();
+
+            // 스킬 ID 리스트를 실제 FreelancerSkill 엔티티 리스트로 변환
+            List<FreelancerSkill> skills = fReq.getSkillIds().stream()
+                    .map(skillId -> {
+                        Skill skill = skillRepository.findById(skillId)
+                                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스킬 ID입니다: " + skillId));
+                        return FreelancerSkill.builder()
+                                .freelancerProfile(profile)
+                                .skill(skill)
+                                .build();
+                    })
+                    .collect(Collectors.toList());
+
+            profile.updateSkills(skills);
+            freelancerProfileRepository.save(profile);
+        }
+
+        // [보고] 모든 DB 저장이 성공적으로 끝나면 권한이 승격된 토큰을 새로 발급
         String newToken = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());
         return new TokenResponse(newToken, "Bearer");
     }
 
-    /**
-     * [추가] 내 정보 조회
-     */
     public UserInfoResponse getUserInfo(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -13,7 +13,7 @@ export default function OnboardingPage() {
     const [role, setRole] = useState("");
 
     const [clientData, setClientData] = useState({
-        companyName: "", representativeName: "", bn: "", introduction: "", homepageUrl: "", phoneNum: "", address: ""
+        companyName: "", representativeName: "", bn: "", introduction: "", homepageUrl: "", phoneNum: ""
     });
 
     const [freelancerData, setFreelancerData] = useState({

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -3,17 +3,35 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import api from "../lib/axios";
+import { AnimatePresence, motion } from "framer-motion";
+import ClientExtraForm from "@/components/onboarding/ClientExtraForm";
+import FreelancerExtraForm from "@/components/onboarding/FreelancerExtraForm";
 
 export default function OnboardingPage() {
+    const [step, setStep] = useState(1); // [추가] 현재 단계 (1, 2, 3)
     const [nickname, setNickname] = useState("");
     const [role, setRole] = useState("");
+
+    const [clientData, setClientData] = useState({
+        companyName: "", representativeName: "", bn: "", introduction: "", homepageUrl: "", phoneNum: "", address: ""
+    });
+
+    const [freelancerData, setFreelancerData] = useState({
+        introduction: "",
+        location: "",
+        latitude: 37.5665,
+        longitude: 126.9780,
+        hourlyRate: 0,
+        workStyle: "HYBRID",
+        skillIds: [] as number[],
+    });
+
     const [loading, setLoading] = useState(true);
     const router = useRouter();
 
     useEffect(() => {
         const checkGuest = async () => {
             try {
-                // api 인스턴스에 이미 baseURL이 /api로 설정되어 있으므로 /api를 빼야 합니다.
                 const res = await api.get("/v1/users/me");
                 const currentRole = res.data.role;
                 if (!(currentRole === "GUEST" || currentRole === "ROLE_GUEST")) {
@@ -29,40 +47,68 @@ export default function OnboardingPage() {
         checkGuest();
     }, [router]);
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        const normalizedNickname = nickname.trim();
-        if (!normalizedNickname) return alert("닉네임을 입력해주세요");
-        if (!role) return alert("역할을 선택해주세요");
+    // [로직] 다음 단계로 이동 제어
+    const handleNext = () => {
+        if (step === 1) {
+            if (!nickname.trim() || !role) return alert("닉네임과 역할을 선택해주세요.");
+            // 역할에 따른 분기: 프리랜서면 바로 3단계로, 아니면 2단계로
+            if (role === "FREELANCER") setStep(3);
+            else setStep(2);
+        } else if (step === 2) {
+            // BOTH면 다음(프리랜서)으로, CLIENT면 바로 제출
+            if (role === "BOTH") setStep(3);
+            else handleSubmit();
+        } else if (step === 3) {
+            handleSubmit();
+        }
+    };
 
+    // [로직] 이전 단계로 이동
+    const handleBack = () => {
+        if (step === 3 && role === "FREELANCER") setStep(1);
+        else setStep(prev => prev - 1);
+    };
+
+    const handleSubmit = async () => {
         setLoading(true);
         try {
-            // api 인스턴스에 이미 baseURL이 /api로 설정되어 있으므로 /api를 빼야 합니다.
-            const res = await api.post("/v1/users/onboarding", { nickname: normalizedNickname, role });
+            const onboardingPayload: any = {
+                nickname: nickname.trim(),
+                role: role,
+            };
 
-            // 토큰이 없으면 여기서 바로 컷! (Fail-Fast)
+            if (role === "CLIENT" || role === "BOTH") {
+                onboardingPayload.clientProfile = clientData;
+            }
+
+            if (role === "FREELANCER" || role === "BOTH") {
+                onboardingPayload.freelancerProfile = freelancerData;
+            }
+
+            const res = await api.post("/v1/users/onboarding", onboardingPayload);
             const newToken = res.data.accessToken;
-            if (!newToken) {
-                throw new Error("인증 토큰을 받지 못했습니다. 다시 로그인해주세요.");
+
+            if (newToken) {
+                localStorage.setItem("accessToken", newToken);
+                api.defaults.headers.common["Authorization"] = `Bearer ${newToken}`;
             }
 
-            // 토큰이 있을 때만 안전하게 저장하고 다음 단계 진행
-            localStorage.setItem("accessToken", newToken);
-            console.log("정식 요원 증표 교체 완료!");
-
-            try {
-                const userRes = await api.get("/v1/users/me");
-                alert(`${userRes.data.nickname}님, 합류를 환영합니다!`);
-            } catch {
-                alert(`${normalizedNickname}님, 합류를 환영합니다!`);
-            }
+            alert("기지 설정 완료! 정식 요원이 되신 것을 환영합니다.");
             router.replace("/");
 
         } catch (err: any) {
-            alert(err.message || err.response?.data?.message || "설정 중 오류 발생");
+            console.error("온보딩 에러:", err);
+            alert(err.response?.data?.message || "설정 중 오류가 발생했습니다.");
         } finally {
             setLoading(false);
         }
+    };
+
+    const stepVariants = {
+        initial: { x: 20, opacity: 0 },
+        animate: { x: 0, opacity: 1 },
+        exit: { x: -20, opacity: 0 },
+        transition: { duration: 0.3 }
     };
 
     if (loading) return (
@@ -72,112 +118,100 @@ export default function OnboardingPage() {
     );
 
     return (
-        <div className="relative flex items-center justify-center min-h-screen overflow-hidden bg-white font-sans text-zinc-900">
+        <div className="relative flex items-center justify-center min-h-screen overflow-x-hidden bg-white font-sans text-zinc-900">
 
-            {/* [배경 레이어 1] 설계도 그리드 */}
-            <div className="absolute inset-0 z-0 opacity-[0.4]"
-                 style={{ backgroundImage: 'linear-gradient(#f0f0f0 1px, transparent 1px), linear-gradient(90deg, #f0f0f0 1px, transparent 1px)', backgroundSize: '40px 40px' }}></div>
-
-            {/* [배경 레이어 2] 메쉬 글로우 */}
+            {/* [배경 레이어 - 기존 유지] */}
+            <div className="absolute inset-0 z-0 opacity-[0.4]" style={{ backgroundImage: 'linear-gradient(#f0f0f0 1px, transparent 1px), linear-gradient(90deg, #f0f0f0 1px, transparent 1px)', backgroundSize: '40px 40px' }}></div>
             <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-[#7A4FFF] opacity-[0.08] blur-[120px] rounded-full"></div>
             <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-[#FF7D00] opacity-[0.08] blur-[120px] rounded-full"></div>
 
-            {/* [배경 레이어 3] 온보딩 전용 코드 데코레이션 */}
-            <div className="absolute inset-0 z-0 overflow-hidden select-none pointer-events-none opacity-[0.12] font-mono text-[11px] md:text-[14px] p-10 leading-relaxed">
-                <div className="absolute top-[15%] left-[5%] rotate-[-3deg] text-[#FF7D00]">
-                    {`@PostMapping("/v1/users/onboarding")\npublic ResponseEntity<?> setupProfile() {\n  return ResponseEntity.ok(new TokenResponse(accessToken));\n}`}
-                </div>
-                <div className="absolute bottom-[20%] left-[8%] rotate-[4deg] text-[#7A4FFF]">
-                    {`const handleOnboarding = async () => {\n  const res = await api.post("/v1/users/onboarding", { nickname, role });\n  localStorage.setItem("accessToken", res.data.accessToken);\n}`}
-                </div>
-                <div className="absolute top-[45%] left-[2%] rotate-[10deg] text-zinc-300">
-                    {`UPDATE members SET \n  nickname = :nickname, \n  role = :role \nWHERE member_id = :id;`}
-                </div>
-                <div className="absolute top-[10%] right-[15%] rotate-[-8deg] text-[#FF7D00]">
-                    {`# Agent Deployment\nmetadata:\n  name: devnear-new-agent\n  labels:\n    status: guest-to-member`}
-                </div>
-                <div className="absolute bottom-[35%] right-[12%] rotate-[-15deg] text-[#7A4FFF]">
-                    {`$ git branch -M main\n$ git add . \n$ git commit -m "feat: complete onboarding"`}
-                </div>
+            {/* [상단 진행 바] */}
+            <div className="fixed top-24 left-1/2 -translate-x-1/2 flex gap-3 z-50">
+                {[1, 2, 3].map((s) => (
+                    <div key={s} className={`h-1.5 rounded-full transition-all duration-500 ${
+                        step === s ? "w-12 bg-[#7A4FFF]" : s < step ? "w-6 bg-zinc-900" : "w-6 bg-zinc-200"
+                    }`} />
+                ))}
             </div>
 
-            {/* [상단 네비게이션] 블랙 배경 + 컬러 로고 */}
             <nav className="w-full py-5 px-10 bg-zinc-950 border-b border-zinc-800 flex justify-between items-center fixed top-0 left-0 z-50">
-                <div className="font-black text-2xl tracking-tighter cursor-default">
-                    <span className="text-[#FF7D00]">Dev</span>
-                    <span className="text-[#7A4FFF]">Near</span>
-                </div>
+                <div className="font-black text-2xl tracking-tighter cursor-default"><span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span></div>
             </nav>
 
-            <div className="relative z-10 max-w-6xl w-full grid md:grid-cols-2 gap-16 items-center px-8 mt-24 mb-12">
-
-                {/* 좌측: 브랜딩 문구 */}
+            <div className="relative z-10 max-w-6xl w-full grid md:grid-cols-2 gap-16 items-center px-8 mt-32 mb-16">
                 <div className="hidden md:block">
-                    <div className="flex items-center gap-2 mb-6">
-                        <span className="w-8 h-[2px] bg-[#FF7D00]"></span>
-                        <span className="text-xs font-bold tracking-widest text-zinc-400 uppercase">Identity Initialization</span>
-                    </div>
-                    <h1 className="text-7xl font-black leading-tight mb-8 tracking-tighter text-zinc-900">
-                        Complete <br />
-                        <span className="text-[#FF7D00]">Profile,</span> <br />
-                        Start <span className="text-[#7A4FFF]">Access.</span>
-                    </h1>
-                    <p className="text-zinc-500 text-xl font-medium max-w-md leading-relaxed">
-                        이제 마지막 단계입니다. <br />
-                        devnear에서 사용할 <span className="text-zinc-900 font-bold">닉네임</span>과 <span className="text-zinc-900 font-bold">역할</span>을 선택하여 정식 회원으로 등록하세요.
-                    </p>
+                    <div className="flex items-center gap-2 mb-6"><span className="w-8 h-[2px] bg-[#FF7D00]"></span><span className="text-xs font-bold tracking-widest text-zinc-400 uppercase">Identity Initialization</span></div>
+                    <h1 className="text-7xl font-black leading-tight mb-8 tracking-tighter text-zinc-900">Complete <br /><span className="text-[#FF7D00]">Profile,</span> <br />Start <span className="text-[#7A4FFF]">Access.</span></h1>
+                    <p className="text-zinc-500 text-xl font-medium max-w-md leading-relaxed">단계별로 정보를 입력하고 <br /><span className="text-zinc-900 font-bold">DevNear</span>의 정식 멤버로 합류하세요.</p>
                 </div>
 
-                {/* 우측: 온보딩 카드 */}
-                <div className="bg-white/95 p-10 md:p-12 shadow-[0_32px_64px_-16px_rgba(0,0,0,0.1)] rounded-[3rem] border border-zinc-100 relative overflow-hidden">
-                    <h2 className="text-3xl font-bold mb-2 text-zinc-900 tracking-tight">회원 정보 설정</h2>
-                    <p className="text-zinc-400 mb-8 text-sm font-medium italic">// Finish setting up your account</p>
+                <div className="bg-white/95 p-10 md:p-12 shadow-[0_32px_64px_-16px_rgba(0,0,0,0.1)] rounded-[3rem] border border-zinc-100 relative overflow-hidden transition-all duration-500 min-h-[500px] flex flex-col">
+                    <div className="flex justify-between items-start mb-8">
+                        <div>
+                            <h2 className="text-3xl font-bold text-zinc-900 tracking-tight">회원 설정 ({step}/3)</h2>
+                            <p className="text-zinc-400 text-sm font-medium italic">// Step {step}: {step === 1 ? "Identity" : step === 2 ? "Business" : "Professional"}</p>
+                        </div>
+                    </div>
 
-                    <form onSubmit={handleSubmit} className="space-y-6">
-                        <div className="space-y-2">
-                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest group-focus-within:text-[#7A4FFF]">Agent Nickname</label>
-                            <input
-                                required
-                                type="text"
-                                value={nickname}
-                                onChange={(e) => setNickname(e.target.value)}
-                                placeholder="활동할 닉네임을 입력하세요"
-                                className="w-full p-4 bg-zinc-50 border border-zinc-100 text-zinc-900 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] focus:bg-white outline-none transition-all placeholder:text-zinc-300"
-                            />
+                    <form className="space-y-6 flex-1 flex flex-col" onSubmit={(e) => e.preventDefault()}>
+                        <div className="flex-1">
+                            <AnimatePresence mode="wait">
+                                {step === 1 && (
+                                    <motion.div key="step1" {...stepVariants}>
+                                        <div className="space-y-6">
+                                            <div className="space-y-2">
+                                                <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Agent Nickname</label>
+                                                <input required type="text" value={nickname} onChange={(e) => setNickname(e.target.value)} placeholder="활동할 닉네임" className="w-full p-4 bg-zinc-50 border border-zinc-100 text-zinc-900 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all" />
+                                            </div>
+                                            <div className="space-y-3">
+                                                <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Select Agent Role</label>
+                                                <div className="grid grid-cols-1 gap-2">
+                                                    {[
+                                                        { id: "FREELANCER", label: "🎨 프리랜서", desc: "나의 기술로 가치를 만들고 싶어요" },
+                                                        { id: "CLIENT", label: "💼 클라이언트", desc: "함께 성장할 파트너를 찾고 있어요" },
+                                                        { id: "BOTH", label: "🚀 둘 다 할래요", desc: "모든 가능성을 열어두고 싶어요" },
+                                                    ].map((opt) => (
+                                                        <div key={opt.id} onClick={() => setRole(opt.id)} className={`p-4 rounded-2xl border-2 text-left cursor-pointer transition-all ${role === opt.id ? "border-zinc-900 bg-zinc-900 text-white" : "border-zinc-50 bg-zinc-50 text-zinc-800 hover:border-zinc-200"}`}>
+                                                            <div className="font-bold text-sm">{opt.label}</div>
+                                                            <div className="text-[10px] opacity-60">{opt.desc}</div>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </motion.div>
+                                )}
+
+                                {step === 2 && (
+                                    <motion.div key="step2" {...stepVariants}>
+                                        <ClientExtraForm clientData={clientData} setClientData={setClientData} />
+                                    </motion.div>
+                                )}
+
+                                {step === 3 && (
+                                    <motion.div key="step3" {...stepVariants}>
+                                        <FreelancerExtraForm freelancerData={freelancerData} setFreelancerData={setFreelancerData} />
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
                         </div>
 
-                        {/* 역할 선택 섹션 */}
-                        <div className="space-y-3 pt-2">
-                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Select Agent Role</label>
-                            <div className="grid grid-cols-1 gap-3">
-                                {[
-                                    { id: "FREELANCER", label: "🎨 프리랜서", desc: "나의 기술로 가치를 만들고 싶어요" },
-                                    { id: "CLIENT", label: "💼 클라이언트", desc: "함께 성장할 파트너를 찾고 있어요" },
-                                    { id: "BOTH", label: "🚀 둘 다 할래요", desc: "모든 가능성을 열어두고 싶어요" },
-                                ].map((opt) => (
-                                    <div
-                                        key={opt.id}
-                                        onClick={() => setRole(opt.id)}
-                                        className={`p-4 rounded-2xl border-2 text-left cursor-pointer transition-all ${
-                                            role === opt.id
-                                                ? "border-zinc-900 bg-zinc-900 text-white"
-                                                : "border-zinc-50 bg-zinc-50 text-zinc-800 hover:border-zinc-200"
-                                        }`}
-                                    >
-                                        <div className="font-bold text-base">{opt.label}</div>
-                                        <div className={`text-xs ${role === opt.id ? "text-zinc-400" : "text-zinc-400"}`}>{opt.desc}</div>
-                                    </div>
-                                ))}
-                            </div>
+                        {/* 하단 버튼 액션 */}
+                        <div className="flex gap-3 pt-6 mt-auto">
+                            {step > 1 && (
+                                <button type="button" onClick={handleBack} className="flex-1 p-4 border border-zinc-200 rounded-2xl font-black text-zinc-400 hover:bg-zinc-50 transition-all">
+                                    이전
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={handleNext}
+                                disabled={loading}
+                                className="flex-[2] bg-zinc-900 text-white p-4 rounded-2xl font-black text-lg hover:bg-gradient-to-r hover:from-[#FF7D00] hover:to-[#7A4FFF] transition-all shadow-lg active:scale-95 disabled:bg-zinc-100"
+                            >
+                                {loading ? "처리 중..." : (step === 3 || (step === 2 && role === "CLIENT")) ? "합류하기" : "다음 단계로"}
+                            </button>
                         </div>
-
-                        <button
-                            type="submit"
-                            disabled={loading || !nickname || !role}
-                            className="w-full bg-zinc-900 text-white p-5 rounded-2xl font-black text-lg hover:bg-gradient-to-r hover:from-[#FF7D00] hover:to-[#7A4FFF] transition-all shadow-lg active:scale-95 disabled:bg-zinc-200 mt-4"
-                        >
-                            {loading ? "기록 중..." : "설정 완료"}
-                        </button>
                     </form>
                 </div>
             </div>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -6,26 +6,76 @@ import api from "../lib/axios";
 import Link from "next/link";
 
 export default function SignupPage() {
-    const [formData, setFormData] = useState({
-        email: "", password: "", name: "", nickname: "", role: "CLIENT",
-    });
-    const [loading, setLoading] = useState(false);
     const router = useRouter();
+    const [loading, setLoading] = useState(false);
 
+    // [상태 관리] 기본 계정 정보
+    const [formData, setFormData] = useState({
+        email: "",
+        password: "",
+        name: "",
+        nickname: "", // 초기값은 빈 값으로 보내고 온보딩에서 정식 설정
+        role: "GUEST"  // 회원가입 직후에는 GUEST 권한을 부여하여 온보딩으로 유도
+    });
+
+    // [상태 관리] 유효성 검사 에러 메시지
+    const [errors, setErrors] = useState({
+        email: "",
+        password: "",
+        name: "",
+    });
+
+    // [로직] 정규표현식 기반 유효성 검사
+    const validate = () => {
+        let isValid = true;
+        const newErrors = { email: "", password: "", name: "" };
+
+        // 1. 이메일 형식 체크
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(formData.email)) {
+            newErrors.email = "타당한 이메일 형식이 아닙니다.";
+            isValid = false;
+        }
+
+        // 2. 비밀번호 형식 체크 (최소 8자, 영문+숫자 혼합)
+       // const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+        //if (!passwordRegex.test(formData.password)) {
+           // newErrors.password = "비밀번호는 8자 이상, 영문과 숫자를 혼합해야 합니다.";
+           // isValid = false;
+        //}
+
+        // 3. 이름 체크 (공백 제외 2자 이상)
+        if (formData.name.trim().length < 2) {
+            newErrors.name = "성함은 최소 2자 이상 입력해 주세요.";
+            isValid = false;
+        }
+
+        setErrors(newErrors);
+        return isValid;
+    };
+
+    // [핸들러] 회원가입 제출
     const handleSignup = async (e: React.FormEvent) => {
         e.preventDefault();
+
+        // 프론트엔드 1차 방어선
+        if (!validate()) return;
+
         setLoading(true);
         try {
+            // 백엔드 /auth/signup API 호출
             await api.post("/auth/signup", formData);
-            alert("회원가입이 완료되었습니다!");
-            router.push("/login");
+            alert("계정 생성이 완료되었습니다! 이제 로그인을 통해 프로필을 설정해 주세요.");
+            router.push("/login"); // 로그인 페이지로 리다이렉트
         } catch (err: any) {
-            alert("입력 정보를 다시 확인해주세요.");
+            console.error("회원가입 에러:", err);
+            alert(err.response?.data?.message || "이미 등록된 이메일이거나 서버 오류가 발생했습니다.");
         } finally {
             setLoading(false);
         }
     };
 
+    // [핸들러] 구글 소셜 로그인
     const handleGoogleLogin = () => {
         const baseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
         window.location.href = `${baseUrl}/oauth2/authorization/google`;
@@ -42,22 +92,22 @@ export default function SignupPage() {
             <div className="absolute top-[-10%] right-[-5%] w-[500px] h-[500px] bg-[#7A4FFF] opacity-[0.08] blur-[120px] rounded-full"></div>
             <div className="absolute bottom-[-10%] left-[-5%] w-[500px] h-[500px] bg-[#FF7D00] opacity-[0.08] blur-[120px] rounded-full"></div>
 
-            {/* [배경 레이어 3] 코드 데코레이션 (마스터 요청으로 선명도 0.25 상향) */}
+            {/* [배경 레이어 3] 코드 데코레이션 */}
             <div className="absolute inset-0 z-0 overflow-hidden select-none pointer-events-none opacity-[0.25] font-mono text-[11px] md:text-[14px] p-10 leading-relaxed">
                 <div className="absolute top-[15%] left-[5%] rotate-[-3deg] text-[#FF7D00]">
                     {`@RestController\npublic class AuthController {\n  @PostMapping("/signup")\n  public ResponseEntity<?> signup() { ... }\n}`}
                 </div>
                 <div className="absolute bottom-[20%] left-[8%] rotate-[4deg] text-[#7A4FFF]">
-                    {`const [formData, setFormData] = useState({\n  role: "CLIENT",\n  tech: "FULLSTACK"\n});`}
+                    {`const [formData, setFormData] = useState({\n  role: "GUEST",\n  status: "PENDING"\n});`}
                 </div>
                 <div className="absolute top-[45%] left-[2%] rotate-[10deg] text-zinc-300">
-                    {`INSERT INTO users (email, nickname, role)\nVALUES (?, ?, ?);`}
+                    {`INSERT INTO users (email, name, role)\nVALUES (?, ?, 'ROLE_GUEST');`}
                 </div>
                 <div className="absolute top-[10%] right-[15%] rotate-[-8deg] text-[#FF7D00]">
-                    {`# Docker Compose\nservices:\n  db:\n    image: mysql:8.0\n    environment:\n      MYSQL_ROOT_PASSWORD: devnear`}
+                    {`# Infrastructure\nservices:\n  auth-service:\n    image: devnear/auth:latest`}
                 </div>
                 <div className="absolute top-[35%] right-[5%] rotate-[2deg] text-zinc-400">
-                    {`# Git Flow\n$ git checkout -b feature/signup-logic\n$ git commit -m "feat: complete onboarding"`}
+                    {`$ git checkout -b feat/user-auth\n$ git commit -m "feat: implement regex validation"`}
                 </div>
             </div>
 
@@ -75,7 +125,7 @@ export default function SignupPage() {
                 <div className="hidden md:block">
                     <div className="flex items-center gap-2 mb-6">
                         <span className="w-8 h-[2px] bg-[#7A4FFF]"></span>
-                        <span className="text-xs font-bold tracking-widest text-zinc-400 uppercase">New Member Registration</span>
+                        <span className="text-xs font-bold tracking-widest text-zinc-400 uppercase">Step 01: Account Setup</span>
                     </div>
                     <h1 className="text-7xl font-black leading-tight mb-8 tracking-tighter text-zinc-900">
                         Join the <br />
@@ -83,76 +133,64 @@ export default function SignupPage() {
                         Share your <span className="text-[#FF7D00]">Skill.</span>
                     </h1>
                     <p className="text-zinc-500 text-xl font-medium max-w-md leading-relaxed">
-                        DevNear의 새로운 회원이 되어 <br />
-                        마스터의 능력을 세상에 타당하게 증명해 보세요.
+                        DevNear의 정식 요원이 되기 위한 첫 단계입니다.<br />
+                        계정 생성 후 마스터만의 특별한 프로필을 완성해 보세요.
                     </p>
                 </div>
 
                 {/* 우측: 회원가입 카드 */}
                 <div className="bg-white/95 p-10 md:p-12 shadow-[0_32px_64px_-16px_rgba(0,0,0,0.15)] rounded-[3rem] border border-zinc-100 relative overflow-hidden group">
-                    <h2 className="text-3xl font-bold mb-2 text-zinc-900 tracking-tight">회원 가입</h2>
-                    <p className="text-zinc-400 mb-8 text-sm font-medium italic">// Create your account to get started</p>
+                    <h2 className="text-3xl font-bold mb-2 text-zinc-900 tracking-tight">계정 생성</h2>
+                    <p className="text-zinc-400 mb-8 text-sm font-medium italic">// Initialize your agent identity</p>
 
                     <form onSubmit={handleSignup} className="space-y-4">
-                        <div className="grid grid-cols-2 gap-4">
-                            <div className="space-y-1">
-                                <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Name</label>
-                                <input
-                                    value={formData.name} // [추가] value 바인딩
-                                    placeholder="실명"
-                                    className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all"
-                                    onChange={(e) => setFormData({...formData, name: e.target.value})} required />
-                            </div>
-                            <div className="space-y-1">
-                                <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Nickname</label>
-                                <input
-                                    value={formData.nickname} // [추가] value 바인딩
-                                    placeholder="닉네임"
-                                    className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all"
-                                    onChange={(e) => setFormData({...formData, nickname: e.target.value})} required />
-                            </div>
-                        </div>
-
+                        {/* Email Input */}
                         <div className="space-y-1">
-                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Email Address</label>
+                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Email Address</label>
                             <input
-                                value={formData.email} // [추가] value 바인딩
-                                type="email" placeholder="example@devnear.com" className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all" onChange={(e) => setFormData({...formData, email: e.target.value})} required />
+                                value={formData.email}
+                                type="email"
+                                placeholder="example@devnear.com"
+                                className={`w-full p-4 bg-zinc-50 border rounded-2xl outline-none transition-all ${errors.email ? 'border-red-400' : 'border-zinc-100 focus:ring-2 focus:ring-[#7A4FFF]'}`}
+                                onChange={(e) => setFormData({...formData, email: e.target.value})}
+                                required
+                            />
+                            {errors.email && <p className="text-[10px] text-red-500 ml-2 font-bold">{errors.email}</p>}
                         </div>
 
+                        {/* Name Input */}
                         <div className="space-y-1">
-                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Password</label>
+                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Full Name</label>
                             <input
-                                value={formData.password} // [추가] value 바인딩
-                                type="password" placeholder="••••••••" className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all" onChange={(e) => setFormData({...formData, password: e.target.value})} required />
+                                value={formData.name}
+                                placeholder="마스터의 성함"
+                                className={`w-full p-4 bg-zinc-50 border rounded-2xl outline-none transition-all ${errors.name ? 'border-red-400' : 'border-zinc-100 focus:ring-2 focus:ring-[#7A4FFF]'}`}
+                                onChange={(e) => setFormData({...formData, name: e.target.value})}
+                                required
+                            />
+                            {errors.name && <p className="text-[10px] text-red-500 ml-2 font-bold">{errors.name}</p>}
                         </div>
 
-                        {/* 역할 선택 */}
-                        <div className="space-y-3 pt-2">
-                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Select Role</label>
-                            <div className="grid grid-cols-3 gap-3">
-                                {[
-                                    { id: "FREELANCER", label: "🎨 프리랜서" },
-                                    { id: "CLIENT", label: "💼 클라이언트" },
-                                    { id: "BOTH", label: "🚀 둘 다 활동" }
-                                ].map((role) => (
-                                    <div
-                                        key={role.id}
-                                        onClick={() => setFormData({...formData, role: role.id})}
-                                        className={`p-3 rounded-2xl border-2 text-center cursor-pointer transition-all ${formData.role === role.id ? 'border-zinc-900 bg-zinc-900 text-white' : 'border-zinc-50 bg-zinc-50 text-zinc-400 hover:border-zinc-200'}`}
-                                    >
-                                        <p className="font-bold text-xs">{role.label}</p>
-                                    </div>
-                                ))}
-                            </div>
+                        {/* Password Input */}
+                        <div className="space-y-1">
+                            <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Password</label>
+                            <input
+                                value={formData.password}
+                                type="password"
+                                placeholder="••••••••"
+                                className={`w-full p-4 bg-zinc-50 border rounded-2xl outline-none transition-all ${errors.password ? 'border-red-400' : 'border-zinc-100 focus:ring-2 focus:ring-[#7A4FFF]'}`}
+                                onChange={(e) => setFormData({...formData, password: e.target.value})}
+                                required
+                            />
+                            {errors.password && <p className="text-[10px] text-red-500 ml-2 font-bold">{errors.password}</p>}
                         </div>
 
                         <button
                             type="submit"
                             disabled={loading}
-                            className="w-full bg-zinc-900 text-white p-4 rounded-2xl font-black text-lg hover:bg-gradient-to-r hover:from-[#FF7D00] hover:to-[#7A4FFF] transition-all shadow-lg active:scale-95 disabled:bg-zinc-200 mt-4"
+                            className="w-full bg-zinc-900 text-white p-5 rounded-2xl font-black text-xl hover:bg-gradient-to-r hover:from-[#FF7D00] hover:to-[#7A4FFF] transition-all shadow-lg active:scale-95 disabled:bg-zinc-200 mt-6"
                         >
-                            {loading ? "등록 중..." : "등록 완료"}
+                            {loading ? "CHECKING..." : "가입 완료"}
                         </button>
                     </form>
 
@@ -161,12 +199,13 @@ export default function SignupPage() {
                         <div className="relative flex justify-center text-[10px] uppercase tracking-widest font-black"><span className="bg-white px-4 text-zinc-300">Or Quick Start</span></div>
                     </div>
 
+                    {/* Google Login Button */}
                     <button
                         onClick={handleGoogleLogin}
                         className="w-full flex items-center justify-center gap-3 border border-zinc-100 p-4 rounded-2xl hover:bg-zinc-50 transition-all font-bold text-zinc-600 mb-6"
                     >
                         <img src="https://www.gstatic.com/images/branding/product/1x/gsa_512dp.png" alt="Google" className="w-5 h-5" />
-                        Google 계정으로 가입
+                        Google 계정으로 계속하기
                     </button>
 
                     <p className="text-center text-sm text-zinc-400 font-medium">

--- a/frontend/components/onboarding/ClientExtraForm.tsx
+++ b/frontend/components/onboarding/ClientExtraForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface ClientExtraFormProps {
+    clientData: {
+        companyName: string;
+        representativeName: string;
+        bn: string;
+        introduction: string;
+        homepageUrl: string;
+        phoneNum: string;
+    };
+    setClientData: (data: any) => void;
+}
+
+export default function ClientExtraForm({ clientData, setClientData }: ClientExtraFormProps) {
+    return (
+        <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+            className="overflow-hidden"
+        >
+            <div className="pt-6 mt-6 border-t border-zinc-100 space-y-4">
+                <div className="flex items-center gap-2 mb-2">
+                    <span className="w-2 h-2 bg-[#FF7D00] rounded-full"></span>
+                    <p className="text-[10px] font-black text-[#FF7D00] uppercase tracking-widest">Business Information</p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Company Name *</label>
+                        <input
+                            value={clientData.companyName}
+                            onChange={(e) => setClientData({ ...clientData, companyName: e.target.value })}
+                            placeholder="회사명 또는 활동명"
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all"
+                            required
+                        />
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Representative *</label>
+                        <input
+                            value={clientData.representativeName}
+                            onChange={(e) => setClientData({ ...clientData, representativeName: e.target.value })}
+                            placeholder="대표자 성함"
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all"
+                            required
+                        />
+                    </div>
+                </div>
+
+                <div className="space-y-1">
+                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Business Number (BN) *</label>
+                    <input
+                        value={clientData.bn}
+                        onChange={(e) => setClientData({ ...clientData, bn: e.target.value })}
+                        placeholder="사업자 등록번호 (10자리)"
+                        className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all"
+                        required
+                    />
+                </div>
+
+                <div className="space-y-1">
+                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Introduction</label>
+                    <textarea
+                        value={clientData.introduction}
+                        onChange={(e) => setClientData({ ...clientData, introduction: e.target.value })}
+                        placeholder="의뢰인 또는 기업에 대해 짧게 소개해 주세요."
+                        className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all min-h-[100px] resize-none"
+                    />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Phone</label>
+                        <input
+                            value={clientData.phoneNum}
+                            onChange={(e) => setClientData({ ...clientData, phoneNum: e.target.value })}
+                            placeholder="010-0000-0000"
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all"
+                        />
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Homepage</label>
+                        <input
+                            value={clientData.homepageUrl}
+                            onChange={(e) => setClientData({ ...clientData, homepageUrl: e.target.value })}
+                            placeholder="https://..."
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#FF7D00] outline-none transition-all"
+                        />
+                    </div>
+                </div>
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/components/onboarding/FreelancerExtraForm.tsx
+++ b/frontend/components/onboarding/FreelancerExtraForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import api from "../../app/lib/axios";
 
 interface FreelancerExtraFormProps {
     freelancerData: {
@@ -16,14 +18,20 @@ interface FreelancerExtraFormProps {
 }
 
 export default function FreelancerExtraForm({ freelancerData, setFreelancerData }: FreelancerExtraFormProps) {
-    // 테스트용 스킬 더미 데이터 (나중에 백엔드 /api/v1/skills 에서 받아와야 함)
-    const availableSkills = [
-        { id: 1, name: "Java", category: "Backend" },
-        { id: 2, name: "React", category: "Frontend" },
-        { id: 3, name: "Spring Boot", category: "Backend" },
-        { id: 4, name: "TypeScript", category: "Frontend" },
-        { id: 5, name: "Figma", category: "Design" },
-    ];
+    const [availableSkills, setAvailableSkills] = useState<{id: number, name: string, category: string}[]>([]);
+
+    useEffect(() => {
+        // [수정] 하드코딩된 스킬 ID를 제거하고 백엔드에서 실시간으로 스킬 목록을 받아옵니다.
+        const fetchSkills = async () => {
+            try {
+                const res = await api.get("/v1/skills/default");
+                setAvailableSkills(res.data);
+            } catch (err) {
+                console.error("스킬 목록을 불러오지 못했습니다.", err);
+            }
+        };
+        fetchSkills();
+    }, []);
 
     const toggleSkill = (skillId: number) => {
         const newSkills = freelancerData.skillIds.includes(skillId)
@@ -48,8 +56,10 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
 
                 {/* 한 줄 소개 */}
                 <div className="space-y-1">
-                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Introduction *</label>
+                    {/* [수정] htmlFor 속성 추가 */}
+                    <label htmlFor="intro-input" className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Introduction *</label>
                     <textarea
+                        id="intro-input"
                         value={freelancerData.introduction}
                         onChange={(e) => setFreelancerData({ ...freelancerData, introduction: e.target.value })}
                         placeholder="마스터의 기술력과 경험을 짧게 소개해 주세요."
@@ -60,8 +70,9 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
                 <div className="grid grid-cols-2 gap-4">
                     {/* 활동 지역 */}
                     <div className="space-y-1">
-                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Location</label>
+                        <label htmlFor="location-input" className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Location</label>
                         <input
+                            id="location-input"
                             value={freelancerData.location}
                             onChange={(e) => setFreelancerData({ ...freelancerData, location: e.target.value })}
                             placeholder="예: 서울시 강남구"
@@ -70,9 +81,12 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
                     </div>
                     {/* 희망 시급 */}
                     <div className="space-y-1">
-                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Hourly Rate (₩) *</label>
+                        <label htmlFor="hourly-rate-input" className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Hourly Rate (₩) *</label>
+                        {/* [수정] min="0" 속성 추가하여 음수 입력 방지 */}
                         <input
+                            id="hourly-rate-input"
                             type="number"
+                            min="0"
                             value={freelancerData.hourlyRate}
                             onChange={(e) => setFreelancerData({ ...freelancerData, hourlyRate: Number(e.target.value) })}
                             placeholder="0"

--- a/frontend/components/onboarding/FreelancerExtraForm.tsx
+++ b/frontend/components/onboarding/FreelancerExtraForm.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface FreelancerExtraFormProps {
+    freelancerData: {
+        introduction: string;
+        location: string;
+        latitude: number;
+        longitude: number;
+        hourlyRate: number;
+        workStyle: string;
+        skillIds: number[];
+    };
+    setFreelancerData: (data: any) => void;
+}
+
+export default function FreelancerExtraForm({ freelancerData, setFreelancerData }: FreelancerExtraFormProps) {
+    // 테스트용 스킬 더미 데이터 (나중에 백엔드 /api/v1/skills 에서 받아와야 함)
+    const availableSkills = [
+        { id: 1, name: "Java", category: "Backend" },
+        { id: 2, name: "React", category: "Frontend" },
+        { id: 3, name: "Spring Boot", category: "Backend" },
+        { id: 4, name: "TypeScript", category: "Frontend" },
+        { id: 5, name: "Figma", category: "Design" },
+    ];
+
+    const toggleSkill = (skillId: number) => {
+        const newSkills = freelancerData.skillIds.includes(skillId)
+            ? freelancerData.skillIds.filter(id => id !== skillId)
+            : [...freelancerData.skillIds, skillId];
+        setFreelancerData({ ...freelancerData, skillIds: newSkills });
+    };
+
+    return (
+        <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+            className="overflow-hidden"
+        >
+            <div className="pt-6 mt-6 border-t border-zinc-100 space-y-5">
+                <div className="flex items-center gap-2 mb-2">
+                    <span className="w-2 h-2 bg-[#7A4FFF] rounded-full"></span>
+                    <p className="text-[10px] font-black text-[#7A4FFF] uppercase tracking-widest">Professional Arsenal</p>
+                </div>
+
+                {/* 한 줄 소개 */}
+                <div className="space-y-1">
+                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Introduction *</label>
+                    <textarea
+                        value={freelancerData.introduction}
+                        onChange={(e) => setFreelancerData({ ...freelancerData, introduction: e.target.value })}
+                        placeholder="마스터의 기술력과 경험을 짧게 소개해 주세요."
+                        className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all min-h-[80px] resize-none text-sm"
+                    />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    {/* 활동 지역 */}
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Location</label>
+                        <input
+                            value={freelancerData.location}
+                            onChange={(e) => setFreelancerData({ ...freelancerData, location: e.target.value })}
+                            placeholder="예: 서울시 강남구"
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all text-sm"
+                        />
+                    </div>
+                    {/* 희망 시급 */}
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Hourly Rate (₩) *</label>
+                        <input
+                            type="number"
+                            value={freelancerData.hourlyRate}
+                            onChange={(e) => setFreelancerData({ ...freelancerData, hourlyRate: Number(e.target.value) })}
+                            placeholder="0"
+                            className="w-full p-3 bg-zinc-50 border border-zinc-100 rounded-2xl focus:ring-2 focus:ring-[#7A4FFF] outline-none transition-all text-sm"
+                        />
+                    </div>
+                </div>
+
+                {/* 작업 방식 (WorkStyle Enum) */}
+                <div className="space-y-1">
+                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Work Style</label>
+                    <div className="flex gap-2">
+                        {["ONLINE", "OFFLINE", "HYBRID"].map((style) => (
+                            <button
+                                key={style}
+                                type="button"
+                                onClick={() => setFreelancerData({ ...freelancerData, workStyle: style })}
+                                className={`flex-1 p-2 rounded-xl text-[10px] font-bold transition-all border ${
+                                    freelancerData.workStyle === style
+                                        ? "bg-zinc-900 text-white border-zinc-900"
+                                        : "bg-white text-zinc-400 border-zinc-100 hover:border-zinc-300"
+                                }`}
+                            >
+                                {style}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* 기술 스택 선택 (DTO: skillIds) */}
+                <div className="space-y-2">
+                    <label className="text-[10px] font-black text-zinc-400 ml-1 uppercase tracking-widest">Tech Stacks * (Min 1)</label>
+                    <div className="flex flex-wrap gap-2">
+                        {availableSkills.map((skill) => (
+                            <div
+                                key={skill.id}
+                                onClick={() => toggleSkill(skill.id)}
+                                className={`px-3 py-1.5 rounded-full text-[11px] font-bold cursor-pointer transition-all border ${
+                                    freelancerData.skillIds.includes(skill.id)
+                                        ? "bg-[#7A4FFF] text-white border-[#7A4FFF] shadow-md"
+                                        : "bg-zinc-50 text-zinc-500 border-zinc-100 hover:bg-zinc-100"
+                                }`}
+                            >
+                                {skill.name}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </motion.div>
+    );
+}

--- a/frontend/components/onboarding/FreelancerExtraForm.tsx
+++ b/frontend/components/onboarding/FreelancerExtraForm.tsx
@@ -18,10 +18,10 @@ interface FreelancerExtraFormProps {
 }
 
 export default function FreelancerExtraForm({ freelancerData, setFreelancerData }: FreelancerExtraFormProps) {
-    const [availableSkills, setAvailableSkills] = useState<{id: number, name: string, category: string}[]>([]);
+    // [수정] 백엔드 DTO(SkillResponse)의 필드명인 skillId를 정확히 명시
+    const [availableSkills, setAvailableSkills] = useState<{skillId: number, name: string, category: string}[]>([]);
 
     useEffect(() => {
-        // [수정] 하드코딩된 스킬 ID를 제거하고 백엔드에서 실시간으로 스킬 목록을 받아옵니다.
         const fetchSkills = async () => {
             try {
                 const res = await api.get("/v1/skills/default");
@@ -56,7 +56,6 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
 
                 {/* 한 줄 소개 */}
                 <div className="space-y-1">
-                    {/* [수정] htmlFor 속성 추가 */}
                     <label htmlFor="intro-input" className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Introduction *</label>
                     <textarea
                         id="intro-input"
@@ -82,7 +81,6 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
                     {/* 희망 시급 */}
                     <div className="space-y-1">
                         <label htmlFor="hourly-rate-input" className="text-[10px] font-black text-zinc-400 ml-1 uppercase">Hourly Rate (₩) *</label>
-                        {/* [수정] min="0" 속성 추가하여 음수 입력 방지 */}
                         <input
                             id="hourly-rate-input"
                             type="number"
@@ -122,10 +120,10 @@ export default function FreelancerExtraForm({ freelancerData, setFreelancerData 
                     <div className="flex flex-wrap gap-2">
                         {availableSkills.map((skill) => (
                             <div
-                                key={skill.id}
-                                onClick={() => toggleSkill(skill.id)}
+                                key={skill.skillId}
+                                onClick={() => toggleSkill(skill.skillId)}
                                 className={`px-3 py-1.5 rounded-full text-[11px] font-bold cursor-pointer transition-all border ${
-                                    freelancerData.skillIds.includes(skill.id)
+                                    freelancerData.skillIds.includes(skill.skillId)
                                         ? "bg-[#7A4FFF] text-white border-[#7A4FFF] shadow-md"
                                         : "bg-zinc-50 text-zinc-500 border-zinc-100 hover:bg-zinc-100"
                                 }`}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "axios": "^1.15.0",
+        "axios": "^1.14.0",
+        "framer-motion": "^12.38.0",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -3690,6 +3691,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5017,6 +5045,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.14.0",
+    "framer-motion": "^12.38.0",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## 🔎 What
FEAT] Next.js 온보딩 페이지를 3단계 위저드(Wizard) UI로 개편
[FEAT] BOTH 요원을 위한 클라이언트 & 프리랜서 프로필 동시 저장 로직 추가
[CHORE] 서버 기동 시 초기 스킬 데이터 자동 생성을 위한 DataInitializer 탑재

## 🔗 Issue

- Closes: #32 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step onboarding with role-based branching and animated transitions
  * Client and freelancer profile forms (business details, skills, rates, work style)
  * Default skills seeded on startup and fetched during onboarding

* **Bug Fixes / Validation**
  * Onboarding request now enforces nested validation for profile payloads

* **Refactor**
  * Onboarding now persists client/freelancer profiles and finalizes token issuance
  * Registration auto-generates nicknames when absent

* **UX**
  * Signup adds client-side validation and defaults role to GUEST
<!-- end of auto-generated comment: release notes by coderabbit.ai -->