### PR TITLE
 feat: 프리랜서 전용 공고 탐색 대시보드 UI 구현 및 필터 로직 고도화

### DIFF
--- a/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
+++ b/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
@@ -60,9 +60,12 @@ public class ProjectController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String location,
             @RequestParam(required = false) String skill,
+            @RequestParam(required = false) Boolean online,
+            @RequestParam(required = false) Boolean offline,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<ProjectResponse> responses = projectService.searchProjects(keyword, location, skill, pageable);
+        // [수정] 프론트엔드 리뷰 반영: 온라인/오프라인 필터 파라미터 추가
+        Page<ProjectResponse> responses = projectService.searchProjects(keyword, location, skill, online, offline, pageable);
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
+++ b/backend/src/main/java/com/devnear/web/controller/project/ProjectController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Project", description = "프로젝트 공고 관련 API")
 @RestController
-@RequestMapping("/api/projects")
+@RequestMapping(value = {"/api/projects", "/api/v1/projects"})
 @RequiredArgsConstructor
 public class ProjectController {
 
@@ -54,12 +54,15 @@ public class ProjectController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "전체 프로젝트 목록 조회", description = "최신순으로 프로젝트 공고를 페이징하여 조회합니다.")
+    @Operation(summary = "전체 프로젝트 목록 조회", description = "필터 및 최신순으로 프로젝트 공고를 페이징하여 조회합니다.")
     @GetMapping
     public ResponseEntity<Page<ProjectResponse>> getProjectList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String skill,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<ProjectResponse> responses = projectService.getProjectList(pageable);
+        Page<ProjectResponse> responses = projectService.searchProjects(keyword, location, skill, pageable);
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
+++ b/backend/src/main/java/com/devnear/web/domain/freelancer/FreelancerProfile.java
@@ -83,6 +83,9 @@ public class FreelancerProfile extends BaseTimeEntity {
         this.averageRating = 0.0;
         this.reviewCount = 0;
         this.completedProjects = 0;
+        
+        // [추가] 500 NPE 에러 방어: Builder로 생성 시 컬렉션이 null이 되지 않도록 빈 리스트로 명시적 초기화
+        this.freelancerSkills = new ArrayList<>();
     }
 
     // [비즈니스 로직] 기본 프로필 데이터 일괄 수정
@@ -108,15 +111,23 @@ public class FreelancerProfile extends BaseTimeEntity {
 
     // [비즈니스 로직] 보유 스킬 목록 갱신
     public void updateSkills(List<FreelancerSkill> rawSkills) {
+        // [추가] 500 NPE 에러 2차 방어: 컬렉션이 혹시라도 null일 경우를 대비
+        if (this.freelancerSkills == null) {
+            this.freelancerSkills = new ArrayList<>();
+        }
+        
         this.freelancerSkills.clear(); // 기존 스킬 데이터베이스에서 자동 비우기
-        for (FreelancerSkill skill : rawSkills) {
-            this.freelancerSkills.add(skill);
-            // 양방향 연관관계 동기화
-            if (skill.getFreelancerProfile() != this) {
-                skill.setFreelancerProfile(this);
+        if (rawSkills != null) {
+            for (FreelancerSkill skill : rawSkills) {
+                this.freelancerSkills.add(skill);
+                // 양방향 연관관계 동기화
+                if (skill.getFreelancerProfile() != this) {
+                    skill.setFreelancerProfile(this);
+                }
             }
         }
     }
+
     // 리뷰 평균 점수를 갱신하는 메서드
     public void updateAverageRating(Double averageRating) {
         this.averageRating = averageRating;

--- a/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-    // 수정/삭제 시 권한 확인 및 상세 조회용 (스킬 정보 포함)
     @Query("SELECT DISTINCT p FROM Project p " +
            "JOIN FETCH p.clientProfile cp " +
            "JOIN FETCH cp.user " +
@@ -32,9 +31,15 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
     Page<Project> findAllByClientProfileAndStatus(ClientProfile clientProfile, ProjectStatus status, Pageable pageable);
 
-    // [수정] 프론트엔드 리뷰 반영: activeTab(온라인/오프라인) 동적 필터링 파라미터 추가
-    @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
-    @Query("SELECT p FROM Project p " +
+    // [수정] 봇 리뷰 반영: countQuery 명시 및 메모리 페이징 방지용 DISTINCT 활용
+    @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user"})
+    @Query(value = "SELECT DISTINCT p FROM Project p " +
+           "WHERE (:keyword IS NULL OR p.projectName LIKE %:keyword% OR p.clientProfile.companyName LIKE %:keyword%) " +
+           "AND (:location IS NULL OR p.location LIKE %:location%) " +
+           "AND (:skill IS NULL OR EXISTS (SELECT 1 FROM ProjectSkill ps JOIN ps.skill s WHERE ps.project = p AND s.name LIKE %:skill%)) " +
+           "AND (:online IS NULL OR p.online = :online) " +
+           "AND (:offline IS NULL OR p.offline = :offline)",
+           countQuery = "SELECT COUNT(DISTINCT p) FROM Project p " +
            "WHERE (:keyword IS NULL OR p.projectName LIKE %:keyword% OR p.clientProfile.companyName LIKE %:keyword%) " +
            "AND (:location IS NULL OR p.location LIKE %:location%) " +
            "AND (:skill IS NULL OR EXISTS (SELECT 1 FROM ProjectSkill ps JOIN ps.skill s WHERE ps.project = p AND s.name LIKE %:skill%)) " +

--- a/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
@@ -32,14 +32,18 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
     Page<Project> findAllByClientProfileAndStatus(ClientProfile clientProfile, ProjectStatus status, Pageable pageable);
 
-    // [추가] 프리랜서 메인 대시보드(Explore)에서 프로젝트 필터 검색용
+    // [수정] 프론트엔드 리뷰 반영: activeTab(온라인/오프라인) 동적 필터링 파라미터 추가
     @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
     @Query("SELECT p FROM Project p " +
            "WHERE (:keyword IS NULL OR p.projectName LIKE %:keyword% OR p.clientProfile.companyName LIKE %:keyword%) " +
            "AND (:location IS NULL OR p.location LIKE %:location%) " +
-           "AND (:skill IS NULL OR EXISTS (SELECT 1 FROM ProjectSkill ps JOIN ps.skill s WHERE ps.project = p AND s.name LIKE %:skill%))")
+           "AND (:skill IS NULL OR EXISTS (SELECT 1 FROM ProjectSkill ps JOIN ps.skill s WHERE ps.project = p AND s.name LIKE %:skill%)) " +
+           "AND (:online IS NULL OR p.online = :online) " +
+           "AND (:offline IS NULL OR p.offline = :offline)")
     Page<Project> searchProjects(@Param("keyword") String keyword, 
                                  @Param("location") String location, 
                                  @Param("skill") String skill, 
+                                 @Param("online") Boolean online,
+                                 @Param("offline") Boolean offline,
                                  Pageable pageable);
 }

--- a/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
+++ b/backend/src/main/java/com/devnear/web/domain/project/ProjectRepository.java
@@ -31,4 +31,15 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
     Page<Project> findAllByClientProfileAndStatus(ClientProfile clientProfile, ProjectStatus status, Pageable pageable);
+
+    // [추가] 프리랜서 메인 대시보드(Explore)에서 프로젝트 필터 검색용
+    @EntityGraph(attributePaths = {"clientProfile", "clientProfile.user", "projectSkills", "projectSkills.skill"})
+    @Query("SELECT p FROM Project p " +
+           "WHERE (:keyword IS NULL OR p.projectName LIKE %:keyword% OR p.clientProfile.companyName LIKE %:keyword%) " +
+           "AND (:location IS NULL OR p.location LIKE %:location%) " +
+           "AND (:skill IS NULL OR EXISTS (SELECT 1 FROM ProjectSkill ps JOIN ps.skill s WHERE ps.project = p AND s.name LIKE %:skill%))")
+    Page<Project> searchProjects(@Param("keyword") String keyword, 
+                                 @Param("location") String location, 
+                                 @Param("skill") String skill, 
+                                 Pageable pageable);
 }

--- a/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
+++ b/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
@@ -110,14 +110,14 @@ public class ProjectService {
                 .map(ProjectResponse::from);
     }
 
-    // [추가] 프리랜서 탐색용 필터 검색 메서드
+    // [수정] 프론트엔드 리뷰 반영: activeTab(온/오프라인) 추가
     @Transactional(readOnly = true)
-    public Page<ProjectResponse> searchProjects(String keyword, String location, String skill, Pageable pageable) {
+    public Page<ProjectResponse> searchProjects(String keyword, String location, String skill, Boolean online, Boolean offline, Pageable pageable) {
         String safeKeyword = (keyword != null && keyword.trim().isEmpty()) ? null : keyword;
         String safeLocation = (location != null && location.trim().isEmpty()) ? null : location;
         String safeSkill = (skill != null && skill.trim().isEmpty()) ? null : skill;
 
-        return projectRepository.searchProjects(safeKeyword, safeLocation, safeSkill, pageable)
+        return projectRepository.searchProjects(safeKeyword, safeLocation, safeSkill, online, offline, pageable)
                 .map(ProjectResponse::from);
     }
 

--- a/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
+++ b/backend/src/main/java/com/devnear/web/service/project/ProjectService.java
@@ -110,6 +110,17 @@ public class ProjectService {
                 .map(ProjectResponse::from);
     }
 
+    // [추가] 프리랜서 탐색용 필터 검색 메서드
+    @Transactional(readOnly = true)
+    public Page<ProjectResponse> searchProjects(String keyword, String location, String skill, Pageable pageable) {
+        String safeKeyword = (keyword != null && keyword.trim().isEmpty()) ? null : keyword;
+        String safeLocation = (location != null && location.trim().isEmpty()) ? null : location;
+        String safeSkill = (skill != null && skill.trim().isEmpty()) ? null : skill;
+
+        return projectRepository.searchProjects(safeKeyword, safeLocation, safeSkill, pageable)
+                .map(ProjectResponse::from);
+    }
+
     @Transactional(readOnly = true)
     public Page<ProjectResponse> getMyProjectList(User user, ProjectStatus status, Pageable pageable) {
         ClientProfile clientProfile = findClientProfileByUser(user);

--- a/frontend/app/freelancer/explore/page.tsx
+++ b/frontend/app/freelancer/explore/page.tsx
@@ -16,11 +16,30 @@ export default function FreelancerExplorePage() {
 
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedLocation, setSelectedLocation] = useState('');
-    const [selectedTech, setSelectedTech] = useState<string[]>([]);
+    
+    // [수정] 봇 리뷰 반영: 백엔드 API가 단일 스킬만 받으므로 단일 선택(String)으로 변경
+    const [selectedTech, setSelectedTech] = useState('');
     const [activeTab, setActiveTab] = useState('전체');
+    
+    // [수정] 봇 리뷰 반영: 정렬 상태 추가
+    const [sort, setSort] = useState('createdAt');
+
+    // [수정] 봇 리뷰 반영: 페이지네이션(무한 스크롤 스타일 '더 보기') 상태 추가
+    const [page, setPage] = useState(0);
+    const [hasMore, setHasMore] = useState(false);
 
     const locations = ['서울', '경기', '인천', '부산', '대구', '원격'];
     const techStacks = ['Java', 'Spring Boot', 'React', 'Next.js', 'MySQL', 'TypeScript'];
+
+    // [복구] 필터 초기화 로직
+    const resetFilters = () => {
+        setSearchQuery('');
+        setSelectedLocation('');
+        setSelectedTech('');
+        setActiveTab('전체');
+        setSort('createdAt');
+        setPage(0);
+    };
 
     useEffect(() => {
         const checkAccess = async () => {
@@ -50,8 +69,8 @@ export default function FreelancerExplorePage() {
         checkAccess();
     }, [router]);
 
-    const fetchProjects = async () => {
-        setLoading(true);
+    const fetchProjects = async (pageNum: number, isLoadMore: boolean = false) => {
+        if (!isLoadMore) setLoading(true);
         try {
             const onlineFilter = activeTab === '온라인' ? true : undefined;
             const offlineFilter = activeTab === '오프라인' ? true : undefined;
@@ -59,90 +78,91 @@ export default function FreelancerExplorePage() {
             const params = {
                 keyword: searchQuery || undefined,
                 location: selectedLocation || undefined,
-                skill: selectedTech.length > 0 ? selectedTech[0] : undefined,
+                skill: selectedTech || undefined,
                 online: onlineFilter,
-                offline: offlineFilter
+                offline: offlineFilter,
+                sort: `${sort},desc`, // 최신순 또는 다른 정렬 조건
+                page: pageNum,
+                size: 10
             };
             const { data } = await api.get('/v1/projects', { params });
 
-            setProjects(data.content || []);
+            if (isLoadMore) {
+                setProjects(prev => [...prev, ...(data.content || [])]);
+            } else {
+                setProjects(data.content || []);
+            }
+            
             setTotalElements(data.totalElements || 0);
+            setHasMore(!data.last); // 마지막 페이지가 아니면 더 보기 버튼 표시
+            
         } catch (err) {
-            console.error("프로젝트 공고를 불러오지 못했습니다.", err);
+            // 콘솔 오염 방지
         } finally {
             setLoading(false);
         }
     };
 
+    // 필터가 변경되면 페이지를 0으로 리셋하고 다시 불러옵니다.
     useEffect(() => {
         if (authorized) {
+            setPage(0);
             const timeoutId = setTimeout(() => {
-                fetchProjects();
+                fetchProjects(0, false);
             }, 300);
             return () => clearTimeout(timeoutId);
         }
-    }, [searchQuery, selectedLocation, selectedTech, activeTab, authorized]);
+    }, [searchQuery, selectedLocation, selectedTech, activeTab, sort, authorized]);
 
-    const toggleTech = (tech: string) => {
-        setSelectedTech(prev =>
-            prev.includes(tech)
-                ? prev.filter((t: string) => t !== tech)
-                : [...prev, tech]
-        );
+    // '더 보기' 버튼 클릭 시 호출
+    const handleLoadMore = () => {
+        const nextPage = page + 1;
+        setPage(nextPage);
+        fetchProjects(nextPage, true);
     };
 
-    const resetFilters = () => {
-        setSearchQuery('');
-        setSelectedLocation('');
-        setSelectedTech([]);
-        setActiveTab('전체');
-    };
+    if (!authorized) return <div className="min-h-screen bg-white flex items-center justify-center text-[#7A4FFF] font-black tracking-widest animate-pulse font-mono uppercase text-xs">System_Authorizing...</div>;
 
-    if (!authorized) return (
-        <div className="min-h-screen bg-white flex items-center justify-center text-[#7A4FFF] font-black tracking-widest animate-pulse font-mono uppercase text-xs">
-            데이터_접근_권한_확인_중...
-        </div>
-    );
-
-    const isFiltered = searchQuery !== '' || selectedLocation !== '' || selectedTech.length > 0 || activeTab !== '전체';
+    const isFiltered = searchQuery !== '' || selectedLocation !== '' || selectedTech !== '' || activeTab !== '전체';
 
     return (
         <div className="min-h-screen bg-[#F9FAFB] text-zinc-900 pb-20 font-sans overflow-x-hidden">
-            {/* 상단 네비게이션 바 (마스터의 기존 스타일 유지) */}
+            {/* 상단 네비게이션 바 */}
             <nav className="w-full py-5 px-10 bg-white/80 backdrop-blur-xl border-b border-zinc-200 flex justify-between items-center sticky top-0 z-50 shadow-sm">
                 <div className="font-black text-2xl tracking-tighter cursor-pointer" onClick={() => router.push("/")}>
                     <span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
                 </div>
                 <div className="flex gap-6 items-center">
                     <button onClick={() => router.push('/profile')} className="text-xs font-bold text-zinc-500 hover:text-zinc-900 tracking-widest transition uppercase font-mono">
-                        나의_프로필
+                        MY_PROFILE
                     </button>
                     <div className="w-8 h-8 rounded-full bg-[#FF7D00] border-2 border-white shadow-sm overflow-hidden">
-                        <img src="https://placehold.co/100x100" alt="profile" className="w-full h-full object-cover" />
+                        <img src="https://placehold.co/100x100" alt="profile" />
                     </div>
                 </div>
             </nav>
 
-            {/* 고도화된 한국어 Hero Header */}
-            <header className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden text-center">
+            {/* Hero Section */}
+            <section className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden">
                 <div className="absolute inset-0 opacity-[0.03] pointer-events-none"
                      style={{ backgroundImage: 'linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)', backgroundSize: '40px 40px' }} />
-                <div className="absolute left-[-20px] bottom-4 opacity-5 hidden lg:block text-[#7A4FFF]">
-                    <BarChart3 size={200} strokeWidth={0.5} />
+
+                <div className="absolute left-[-20px] bottom-4 opacity-10 hidden lg:block">
+                    <BarChart3 size={200} className="text-[#7A4FFF]" strokeWidth={0.5} />
                 </div>
-                <div className="absolute right-[-40px] top-10 opacity-5 hidden lg:block rotate-12 text-[#FF7D00]">
-                    <Activity size={240} strokeWidth={0.5} />
+                <div className="absolute right-[-40px] top-10 opacity-10 hidden lg:block rotate-12">
+                    <Activity size={240} className="text-[#FF7D00]" strokeWidth={0.5} />
                 </div>
 
-                <div className="max-w-4xl mx-auto relative z-10">
+                <div className="max-w-4xl mx-auto text-center relative z-10">
                     <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4 text-zinc-900">
-                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾으세요.
+                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4">
+                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾아보세요.
                         </h1>
                         <div className="flex items-center justify-center gap-2 mb-10">
                             <span className="h-[1px] w-8 bg-zinc-200" />
-                            <p className="text-zinc-400 text-[10px] font-mono tracking-[0.2em] uppercase">
-                                가용한_미션_데이터베이스_v2.0
+                            <p className="text-zinc-400 text-[10px] font-mono tracking-widest uppercase">
+                                Available_Missions_Database_v2.0
                             </p>
                             <span className="h-[1px] w-8 bg-zinc-200" />
                         </div>
@@ -152,141 +172,160 @@ export default function FreelancerExplorePage() {
                         <Search className="absolute left-6 top-1/2 -translate-y-1/2 text-zinc-300 group-focus-within:text-[#7A4FFF] transition-colors" size={20} />
                         <input
                             type="text"
-                            placeholder="기술 스택, 프로젝트명, 기업 검색..."
-                            className="w-full bg-white border border-zinc-200 rounded-full py-5 pl-16 pr-6 focus:ring-4 focus:ring-purple-500/5 focus:border-[#7A4FFF] outline-none transition-all font-bold text-sm shadow-xl shadow-purple-900/5"
+                            placeholder="기술 스택, 프로젝트명 검색..."
+                            className="w-full bg-white border-2 border-zinc-200 rounded-full py-5 pl-16 pr-6 focus:ring-4 focus:ring-purple-500/5 focus:border-[#7A4FFF] outline-none transition-all font-bold text-sm shadow-xl shadow-purple-900/5"
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
                         />
                     </div>
                 </div>
-            </header>
+            </section>
 
-            <main className="max-w-6xl mx-auto px-6 md:px-10 py-10 flex flex-col lg:flex-row gap-10">
-                {/* 좌측 사이드바 필터 */}
-                <aside className="w-full lg:w-64 shrink-0 space-y-8">
-                    <section>
-                        <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm">
-                            {['전체', '온라인', '오프라인'].map((tab) => (
-                                <button
-                                    key={tab}
-                                    onClick={() => setActiveTab(tab)}
-                                    className={`flex-1 py-2.5 rounded-xl text-[11px] font-black transition-all ${
-                                        activeTab === tab ? 'bg-zinc-900 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-900'
-                                    }`}
-                                >
-                                    {tab}
-                                </button>
-                            ))}
-                        </div>
-                    </section>
+            <main className="max-w-5xl mx-auto px-6 mt-10">
+                <div className="flex flex-col md:flex-row items-center justify-between gap-6 mb-8">
+                    {/* 프로젝트 유형 탭 */}
+                    <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm overflow-x-auto no-scrollbar">
+                        {['전체', '온라인', '오프라인'].map((tab) => (
+                            <button
+                                key={tab}
+                                onClick={() => setActiveTab(tab)}
+                                className={`px-6 py-2 rounded-xl text-[11px] font-black transition-all whitespace-nowrap ${
+                                    activeTab === tab
+                                        ? 'bg-[#7A4FFF] text-white shadow-md'
+                                        : 'text-zinc-400 hover:text-zinc-900'
+                                }`}
+                            >
+                                {tab}
+                            </button>
+                        ))}
+                    </div>
 
-                    <section>
-                        <div className="flex items-center justify-between mb-4">
-                            <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase text-zinc-400 font-mono">
-                                <MapPin size={14} /> 활동_지역
-                            </h3>
-                            {selectedLocation && (
-                                <button onClick={() => setSelectedLocation('')} className="text-[10px] text-[#FF7D00] font-bold">초기화</button>
-                            )}
-                        </div>
-                        <div className="flex flex-wrap gap-1.5">
-                            {locations.map(loc => (
+                    {/* 지역 필터 및 초기화 */}
+                    <div className="flex items-center gap-4 w-full md:w-auto overflow-hidden">
+                        <div className="flex gap-2 overflow-x-auto no-scrollbar py-1">
+                            {locations.map((loc) => (
                                 <button
                                     key={loc}
                                     onClick={() => setSelectedLocation(loc === selectedLocation ? '' : loc)}
-                                    className={`px-3 py-2 rounded-xl text-[11px] font-bold border transition-all ${
-                                        selectedLocation === loc ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50' : 'bg-white border-zinc-200 text-zinc-500 shadow-sm hover:border-zinc-300'
+                                    className={`px-4 py-1.5 rounded-full text-[10px] font-bold border transition-all whitespace-nowrap ${
+                                        selectedLocation === loc
+                                            ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50 shadow-sm'
+                                            : 'border-zinc-200 text-zinc-500 bg-white hover:border-zinc-300'
                                     }`}
                                 >
                                     {loc}
                                 </button>
                             ))}
                         </div>
-                    </section>
 
-                    <section>
-                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
-                            <Cpu size={14} /> 기술_스택
-                        </h3>
-                        <div className="grid grid-cols-2 gap-2">
-                            {techStacks.map(tech => (
-                                <button
-                                    key={tech}
-                                    onClick={() => toggleTech(tech)}
-                                    className={`px-3 py-2.5 rounded-xl text-[10px] font-bold text-left transition-all border ${
-                                        selectedTech.includes(tech) ? 'bg-zinc-900 border-zinc-900 text-white shadow-md' : 'bg-white border-zinc-100 text-zinc-500 hover:border-zinc-300 shadow-sm'
-                                    }`}
+                        {isFiltered && (
+                            <motion.button
+                                initial={{ opacity: 0, x: -10 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                onClick={resetFilters}
+                                className="shrink-0 flex items-center gap-1.5 text-[10px] font-black text-zinc-400 hover:text-[#FF7D00] transition-colors uppercase font-mono group"
+                            >
+                                <RotateCcw size={12} className="group-hover:rotate-[-45deg] transition-transform" />
+                                Reset
+                            </motion.button>
+                        )}
+                    </div>
+                </div>
+
+                <div className="flex flex-col lg:flex-row gap-10">
+                    {/* 좌측 사이드바 필터 */}
+                    <aside className="w-full lg:w-64 shrink-0 space-y-8">
+                        <section>
+                            <h3 className="flex items-center gap-2 font-black text-xs tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                                <Cpu size={14} /> Tech_Stacks
+                            </h3>
+                            <div className="grid grid-cols-2 gap-2">
+                                {techStacks.map(tech => (
+                                    <button
+                                        key={tech}
+                                        // [수정] 다중 선택에서 단일 선택으로 변경 (토글 기능 유지)
+                                        onClick={() => setSelectedTech(selectedTech === tech ? '' : tech)}
+                                        className={`px-3 py-2 rounded-xl text-[10px] font-bold text-left transition-all border ${
+                                            selectedTech === tech
+                                                ? 'bg-zinc-900 border-zinc-900 text-white shadow-md'
+                                                : 'bg-white border-zinc-100 text-zinc-500 hover:border-zinc-300 shadow-sm'
+                                        }`}
+                                    >
+                                        {selectedTech === tech ? '● ' : '○ '} {tech}
+                                    </button>
+                                ))}
+                            </div>
+                        </section>
+
+                        <section>
+                            <h3 className="flex items-center gap-2 font-black text-xs tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                                <DollarSign size={14} /> Budget_Range
+                            </h3>
+                            <div className="p-4 bg-zinc-50 rounded-2xl border border-zinc-100 opacity-50 pointer-events-none">
+                                <input type="range" className="w-full accent-[#FF7D00]" min="0" max="2000" disabled />
+                                <div className="flex justify-between mt-2 font-mono text-[9px] text-zinc-400 font-bold">
+                                    <span>MIN</span>
+                                    <span>MAX</span>
+                                </div>
+                                <p className="text-[9px] text-center mt-2 text-zinc-400 font-bold">지원 준비 중</p>
+                            </div>
+                        </section>
+                    </aside>
+
+                    {/* 우측 공고 리스트 */}
+                    <section className="flex-1">
+                        <div className="flex justify-between items-end mb-6 border-b border-zinc-100 pb-4">
+                            <p className="font-mono text-[11px] font-black text-zinc-900 uppercase tracking-tighter">
+                                Total_Missions: <span className="text-[#FF7D00]">{totalElements}</span>
+                            </p>
+                            
+                            {/* [수정] 봇 리뷰 반영: 가짜 버튼 대신 실제 API와 연동되는 정렬(select) 도입 */}
+                            <div className="flex items-center gap-2 text-[10px] font-black uppercase font-mono text-zinc-400">
+                                SORT: 
+                                <select 
+                                    className="bg-transparent text-zinc-900 outline-none cursor-pointer hover:text-[#7A4FFF] transition-colors"
+                                    value={sort}
+                                    onChange={(e) => setSort(e.target.value)}
                                 >
-                                    {selectedTech.includes(tech) ? '● ' : '○ '} {tech}
-                                </button>
-                            ))}
-                        </div>
-                    </section>
-
-                    <section>
-                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
-                            <DollarSign size={14} /> 희망_예산
-                        </h3>
-                        <div className="p-5 bg-white rounded-2xl border border-zinc-100 shadow-inner opacity-40">
-                            <input type="range" className="w-full accent-[#FF7D00]" disabled />
-                            <div className="flex justify-between mt-2 font-mono text-[9px] text-zinc-400 font-bold">
-                                <span>최소</span>
-                                <span>최대</span>
+                                    <option value="createdAt">LATEST (최신순)</option>
+                                    <option value="budget">BUDGET (예산순)</option>
+                                </select>
                             </div>
                         </div>
-                    </section>
 
-                    {isFiltered && (
-                        <button
-                            onClick={resetFilters}
-                            className="w-full flex items-center justify-center gap-2 py-4 bg-zinc-100 text-zinc-400 rounded-2xl text-[11px] font-black uppercase font-mono hover:bg-[#FF7D00] hover:text-white transition-all group shadow-sm"
-                        >
-                            <RotateCcw size={14} className="group-hover:rotate-[-45deg] transition-transform" />
-                            필터_설정_초기화
-                        </button>
-                    )}
-                </aside>
-
-                {/* 우측 공고 리스트 */}
-                <section className="flex-1">
-                    <div className="flex justify-between items-center mb-6 px-2">
-                        <div className="flex items-center gap-2">
-                            <div className="w-2 h-2 rounded-full bg-[#7A4FFF] animate-pulse" />
-                            <p className="font-mono text-[10px] font-black text-zinc-500 uppercase tracking-widest">
-                                모집_중인_미션: <span className="text-[#FF7D00]">{totalElements}</span>
-                            </p>
-                        </div>
-                        <button className="flex items-center gap-1 text-[10px] font-black uppercase font-mono text-zinc-400 hover:text-zinc-600">
-                            정렬: 최신순 <ChevronDown size={14} />
-                        </button>
-                    </div>
-
-                    {loading ? (
-                        <div className="flex flex-col items-center justify-center py-24 gap-4">
-                            <div className="w-10 h-10 border-4 border-[#7A4FFF]/20 border-t-[#7A4FFF] rounded-full animate-spin" />
-                            <p className="text-[10px] font-mono font-black text-zinc-300 tracking-[0.2em] uppercase">데이터_동기화_중...</p>
-                        </div>
-                    ) : projects.length > 0 ? (
                         <div className="grid grid-cols-1 gap-5">
                             <AnimatePresence mode="popLayout">
                                 {projects.map((project, idx) => (
                                     <ProjectCard key={project.projectId || project.id} data={project} index={idx} />
                                 ))}
                             </AnimatePresence>
+
+                            {/* [수정] 봇 리뷰 반영: 무한 스크롤/페이지네이션 '더 보기' 버튼 추가 */}
+                            {hasMore && (
+                                <motion.button
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    onClick={handleLoadMore}
+                                    className="w-full py-4 mt-4 bg-white border border-zinc-200 rounded-2xl font-black text-[11px] text-zinc-500 uppercase tracking-widest font-mono hover:bg-zinc-50 hover:text-zinc-900 transition-all shadow-sm"
+                                >
+                                    Load_More_Missions
+                                </motion.button>
+                            )}
+
+                            {!loading && projects.length === 0 && (
+                                <div className="text-center py-28 bg-white rounded-[2.5rem] border border-dashed border-zinc-200 shadow-sm">
+                                    <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">No_Matching_Missions</h3>
+                                    <button
+                                        onClick={resetFilters}
+                                        className="px-8 py-3 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] transition-all shadow-xl active:scale-95"
+                                    >
+                                        RELOAD_SYSTEM
+                                    </button>
+                                </div>
+                            )}
                         </div>
-                    ) : (
-                        <div className="text-center py-32 bg-white rounded-[2.5rem] border border-dashed border-zinc-200 shadow-sm">
-                            <Search className="w-12 h-12 text-zinc-200 mx-auto mb-6" />
-                            <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">일치하는_미션을_찾지_못함</h3>
-                            <button
-                                onClick={resetFilters}
-                                className="px-10 py-4 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] shadow-xl active:scale-95 transition-all"
-                            >
-                                검색_조건_재설정
-                            </button>
-                        </div>
-                    )}
-                </section>
+                    </section>
+                </div>
             </main>
         </div>
     );

--- a/frontend/app/freelancer/explore/page.tsx
+++ b/frontend/app/freelancer/explore/page.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Search, MapPin, DollarSign, Cpu, ChevronDown, RotateCcw, BarChart3, Activity } from 'lucide-react';
+import ProjectCard from "@/components/freelancer/ProjectCard";
+import { useRouter } from 'next/navigation';
+import api from '@/app/lib/axios';
+
+export default function FreelancerExplorePage() {
+    const router = useRouter();
+    const [projects, setProjects] = useState<any[]>([]);
+    const [totalElements, setTotalElements] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [authorized, setAuthorized] = useState(false);
+
+    const [searchQuery, setSearchQuery] = useState('');
+    const [selectedLocation, setSelectedLocation] = useState('');
+    const [selectedTech, setSelectedTech] = useState<string[]>([]);
+    const [activeTab, setActiveTab] = useState('전체');
+
+    const locations = ['서울', '경기', '인천', '부산', '대구', '원격'];
+    const techStacks = ['Java', 'Spring Boot', 'React', 'Next.js', 'MySQL', 'TypeScript'];
+
+    useEffect(() => {
+        const checkAccess = async () => {
+            const token = localStorage.getItem("accessToken");
+            if (!token) {
+                alert("로그인이 필요합니다.");
+                router.replace("/login");
+                return;
+            }
+            try {
+                const res = await api.get("/v1/users/me");
+                const role = res.data.role;
+                if (role === "GUEST" || role === "ROLE_GUEST") {
+                    router.replace("/onboarding");
+                    return;
+                }
+                if (role === "CLIENT" || role === "ROLE_CLIENT") {
+                    alert("프리랜서 전용 화면입니다.");
+                    router.replace("/dashboard");
+                    return;
+                }
+                setAuthorized(true);
+            } catch (err) {
+                router.replace("/login");
+            }
+        };
+        checkAccess();
+    }, [router]);
+
+    const fetchProjects = async () => {
+        setLoading(true);
+        try {
+            const onlineFilter = activeTab === '온라인' ? true : undefined;
+            const offlineFilter = activeTab === '오프라인' ? true : undefined;
+
+            const params = {
+                keyword: searchQuery || undefined,
+                location: selectedLocation || undefined,
+                skill: selectedTech.length > 0 ? selectedTech[0] : undefined,
+                online: onlineFilter,
+                offline: offlineFilter
+            };
+            const { data } = await api.get('/v1/projects', { params });
+
+            setProjects(data.content || []);
+            setTotalElements(data.totalElements || 0);
+        } catch (err) {
+            console.error("프로젝트 공고를 불러오지 못했습니다.", err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (authorized) {
+            const timeoutId = setTimeout(() => {
+                fetchProjects();
+            }, 300);
+            return () => clearTimeout(timeoutId);
+        }
+    }, [searchQuery, selectedLocation, selectedTech, activeTab, authorized]);
+
+    const toggleTech = (tech: string) => {
+        setSelectedTech(prev =>
+            prev.includes(tech)
+                ? prev.filter((t: string) => t !== tech)
+                : [...prev, tech]
+        );
+    };
+
+    const resetFilters = () => {
+        setSearchQuery('');
+        setSelectedLocation('');
+        setSelectedTech([]);
+        setActiveTab('전체');
+    };
+
+    if (!authorized) return (
+        <div className="min-h-screen bg-white flex items-center justify-center text-[#7A4FFF] font-black tracking-widest animate-pulse font-mono uppercase text-xs">
+            데이터_접근_권한_확인_중...
+        </div>
+    );
+
+    const isFiltered = searchQuery !== '' || selectedLocation !== '' || selectedTech.length > 0 || activeTab !== '전체';
+
+    return (
+        <div className="min-h-screen bg-[#F9FAFB] text-zinc-900 pb-20 font-sans overflow-x-hidden">
+            {/* 상단 네비게이션 바 (마스터의 기존 스타일 유지) */}
+            <nav className="w-full py-5 px-10 bg-white/80 backdrop-blur-xl border-b border-zinc-200 flex justify-between items-center sticky top-0 z-50 shadow-sm">
+                <div className="font-black text-2xl tracking-tighter cursor-pointer" onClick={() => router.push("/")}>
+                    <span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
+                </div>
+                <div className="flex gap-6 items-center">
+                    <button onClick={() => router.push('/profile')} className="text-xs font-bold text-zinc-500 hover:text-zinc-900 tracking-widest transition uppercase font-mono">
+                        나의_프로필
+                    </button>
+                    <div className="w-8 h-8 rounded-full bg-[#FF7D00] border-2 border-white shadow-sm overflow-hidden">
+                        <img src="https://placehold.co/100x100" alt="profile" className="w-full h-full object-cover" />
+                    </div>
+                </div>
+            </nav>
+
+            {/* 고도화된 한국어 Hero Header */}
+            <header className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden text-center">
+                <div className="absolute inset-0 opacity-[0.03] pointer-events-none"
+                     style={{ backgroundImage: 'linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)', backgroundSize: '40px 40px' }} />
+                <div className="absolute left-[-20px] bottom-4 opacity-5 hidden lg:block text-[#7A4FFF]">
+                    <BarChart3 size={200} strokeWidth={0.5} />
+                </div>
+                <div className="absolute right-[-40px] top-10 opacity-5 hidden lg:block rotate-12 text-[#FF7D00]">
+                    <Activity size={240} strokeWidth={0.5} />
+                </div>
+
+                <div className="max-w-4xl mx-auto relative z-10">
+                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4 text-zinc-900">
+                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾으세요.
+                        </h1>
+                        <div className="flex items-center justify-center gap-2 mb-10">
+                            <span className="h-[1px] w-8 bg-zinc-200" />
+                            <p className="text-zinc-400 text-[10px] font-mono tracking-[0.2em] uppercase">
+                                가용한_미션_데이터베이스_v2.0
+                            </p>
+                            <span className="h-[1px] w-8 bg-zinc-200" />
+                        </div>
+                    </motion.div>
+
+                    <div className="max-w-2xl mx-auto relative group">
+                        <Search className="absolute left-6 top-1/2 -translate-y-1/2 text-zinc-300 group-focus-within:text-[#7A4FFF] transition-colors" size={20} />
+                        <input
+                            type="text"
+                            placeholder="기술 스택, 프로젝트명, 기업 검색..."
+                            className="w-full bg-white border border-zinc-200 rounded-full py-5 pl-16 pr-6 focus:ring-4 focus:ring-purple-500/5 focus:border-[#7A4FFF] outline-none transition-all font-bold text-sm shadow-xl shadow-purple-900/5"
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                        />
+                    </div>
+                </div>
+            </header>
+
+            <main className="max-w-6xl mx-auto px-6 md:px-10 py-10 flex flex-col lg:flex-row gap-10">
+                {/* 좌측 사이드바 필터 */}
+                <aside className="w-full lg:w-64 shrink-0 space-y-8">
+                    <section>
+                        <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm">
+                            {['전체', '온라인', '오프라인'].map((tab) => (
+                                <button
+                                    key={tab}
+                                    onClick={() => setActiveTab(tab)}
+                                    className={`flex-1 py-2.5 rounded-xl text-[11px] font-black transition-all ${
+                                        activeTab === tab ? 'bg-zinc-900 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-900'
+                                    }`}
+                                >
+                                    {tab}
+                                </button>
+                            ))}
+                        </div>
+                    </section>
+
+                    <section>
+                        <div className="flex items-center justify-between mb-4">
+                            <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase text-zinc-400 font-mono">
+                                <MapPin size={14} /> 활동_지역
+                            </h3>
+                            {selectedLocation && (
+                                <button onClick={() => setSelectedLocation('')} className="text-[10px] text-[#FF7D00] font-bold">초기화</button>
+                            )}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {locations.map(loc => (
+                                <button
+                                    key={loc}
+                                    onClick={() => setSelectedLocation(loc === selectedLocation ? '' : loc)}
+                                    className={`px-3 py-2 rounded-xl text-[11px] font-bold border transition-all ${
+                                        selectedLocation === loc ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50' : 'bg-white border-zinc-200 text-zinc-500 shadow-sm hover:border-zinc-300'
+                                    }`}
+                                >
+                                    {loc}
+                                </button>
+                            ))}
+                        </div>
+                    </section>
+
+                    <section>
+                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                            <Cpu size={14} /> 기술_스택
+                        </h3>
+                        <div className="grid grid-cols-2 gap-2">
+                            {techStacks.map(tech => (
+                                <button
+                                    key={tech}
+                                    onClick={() => toggleTech(tech)}
+                                    className={`px-3 py-2.5 rounded-xl text-[10px] font-bold text-left transition-all border ${
+                                        selectedTech.includes(tech) ? 'bg-zinc-900 border-zinc-900 text-white shadow-md' : 'bg-white border-zinc-100 text-zinc-500 hover:border-zinc-300 shadow-sm'
+                                    }`}
+                                >
+                                    {selectedTech.includes(tech) ? '● ' : '○ '} {tech}
+                                </button>
+                            ))}
+                        </div>
+                    </section>
+
+                    <section>
+                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                            <DollarSign size={14} /> 희망_예산
+                        </h3>
+                        <div className="p-5 bg-white rounded-2xl border border-zinc-100 shadow-inner opacity-40">
+                            <input type="range" className="w-full accent-[#FF7D00]" disabled />
+                            <div className="flex justify-between mt-2 font-mono text-[9px] text-zinc-400 font-bold">
+                                <span>최소</span>
+                                <span>최대</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {isFiltered && (
+                        <button
+                            onClick={resetFilters}
+                            className="w-full flex items-center justify-center gap-2 py-4 bg-zinc-100 text-zinc-400 rounded-2xl text-[11px] font-black uppercase font-mono hover:bg-[#FF7D00] hover:text-white transition-all group shadow-sm"
+                        >
+                            <RotateCcw size={14} className="group-hover:rotate-[-45deg] transition-transform" />
+                            필터_설정_초기화
+                        </button>
+                    )}
+                </aside>
+
+                {/* 우측 공고 리스트 */}
+                <section className="flex-1">
+                    <div className="flex justify-between items-center mb-6 px-2">
+                        <div className="flex items-center gap-2">
+                            <div className="w-2 h-2 rounded-full bg-[#7A4FFF] animate-pulse" />
+                            <p className="font-mono text-[10px] font-black text-zinc-500 uppercase tracking-widest">
+                                모집_중인_미션: <span className="text-[#FF7D00]">{totalElements}</span>
+                            </p>
+                        </div>
+                        <button className="flex items-center gap-1 text-[10px] font-black uppercase font-mono text-zinc-400 hover:text-zinc-600">
+                            정렬: 최신순 <ChevronDown size={14} />
+                        </button>
+                    </div>
+
+                    {loading ? (
+                        <div className="flex flex-col items-center justify-center py-24 gap-4">
+                            <div className="w-10 h-10 border-4 border-[#7A4FFF]/20 border-t-[#7A4FFF] rounded-full animate-spin" />
+                            <p className="text-[10px] font-mono font-black text-zinc-300 tracking-[0.2em] uppercase">데이터_동기화_중...</p>
+                        </div>
+                    ) : projects.length > 0 ? (
+                        <div className="grid grid-cols-1 gap-5">
+                            <AnimatePresence mode="popLayout">
+                                {projects.map((project, idx) => (
+                                    <ProjectCard key={project.projectId || project.id} data={project} index={idx} />
+                                ))}
+                            </AnimatePresence>
+                        </div>
+                    ) : (
+                        <div className="text-center py-32 bg-white rounded-[2.5rem] border border-dashed border-zinc-200 shadow-sm">
+                            <Search className="w-12 h-12 text-zinc-200 mx-auto mb-6" />
+                            <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">일치하는_미션을_찾지_못함</h3>
+                            <button
+                                onClick={resetFilters}
+                                className="px-10 py-4 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] shadow-xl active:scale-95 transition-all"
+                            >
+                                검색_조건_재설정
+                            </button>
+                        </div>
+                    )}
+                </section>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/freelancer/explore/page.tsx
+++ b/frontend/app/freelancer/explore/page.tsx
@@ -16,30 +16,18 @@ export default function FreelancerExplorePage() {
 
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedLocation, setSelectedLocation] = useState('');
-    
-    // [수정] 봇 리뷰 반영: 백엔드 API가 단일 스킬만 받으므로 단일 선택(String)으로 변경
     const [selectedTech, setSelectedTech] = useState('');
     const [activeTab, setActiveTab] = useState('전체');
-    
-    // [수정] 봇 리뷰 반영: 정렬 상태 추가
     const [sort, setSort] = useState('createdAt');
 
-    // [수정] 봇 리뷰 반영: 페이지네이션(무한 스크롤 스타일 '더 보기') 상태 추가
     const [page, setPage] = useState(0);
     const [hasMore, setHasMore] = useState(false);
+    
+    // [수정] 무한 클릭 방지용 상태
+    const [fetchingMore, setFetchingMore] = useState(false);
 
     const locations = ['서울', '경기', '인천', '부산', '대구', '원격'];
     const techStacks = ['Java', 'Spring Boot', 'React', 'Next.js', 'MySQL', 'TypeScript'];
-
-    // [복구] 필터 초기화 로직
-    const resetFilters = () => {
-        setSearchQuery('');
-        setSelectedLocation('');
-        setSelectedTech('');
-        setActiveTab('전체');
-        setSort('createdAt');
-        setPage(0);
-    };
 
     useEffect(() => {
         const checkAccess = async () => {
@@ -71,6 +59,8 @@ export default function FreelancerExplorePage() {
 
     const fetchProjects = async (pageNum: number, isLoadMore: boolean = false) => {
         if (!isLoadMore) setLoading(true);
+        else setFetchingMore(true);
+
         try {
             const onlineFilter = activeTab === '온라인' ? true : undefined;
             const offlineFilter = activeTab === '오프라인' ? true : undefined;
@@ -81,7 +71,7 @@ export default function FreelancerExplorePage() {
                 skill: selectedTech || undefined,
                 online: onlineFilter,
                 offline: offlineFilter,
-                sort: `${sort},desc`, // 최신순 또는 다른 정렬 조건
+                sort: `${sort},desc`,
                 page: pageNum,
                 size: 10
             };
@@ -94,16 +84,38 @@ export default function FreelancerExplorePage() {
             }
             
             setTotalElements(data.totalElements || 0);
-            setHasMore(!data.last); // 마지막 페이지가 아니면 더 보기 버튼 표시
+            setHasMore(!data.last); 
+            
+            // [수정] 데이터 로드가 완벽히 성공했을 때만 page 상태를 업데이트합니다!
+            if (isLoadMore) {
+                setPage(pageNum);
+            }
             
         } catch (err) {
-            // 콘솔 오염 방지
+            console.error("프로젝트 공고를 불러오지 못했습니다.", err);
         } finally {
-            setLoading(false);
+            if (!isLoadMore) setLoading(false);
+            else setFetchingMore(false);
         }
     };
 
-    // 필터가 변경되면 페이지를 0으로 리셋하고 다시 불러옵니다.
+    // [수정] 단순 상태 초기화뿐만 아니라, 명시적으로 데이터를 다시 불러와서 '새로고침' 역할을 확실히 합니다.
+    const resetFilters = () => {
+        // 이미 기본값일 때를 대비해 명시적 호출
+        const isDefault = searchQuery === '' && selectedLocation === '' && selectedTech === '' && activeTab === '전체' && sort === 'createdAt';
+        
+        setSearchQuery('');
+        setSelectedLocation('');
+        setSelectedTech('');
+        setActiveTab('전체');
+        setSort('createdAt');
+        setPage(0);
+
+        if (isDefault) {
+            fetchProjects(0, false);
+        }
+    };
+
     useEffect(() => {
         if (authorized) {
             setPage(0);
@@ -114,10 +126,10 @@ export default function FreelancerExplorePage() {
         }
     }, [searchQuery, selectedLocation, selectedTech, activeTab, sort, authorized]);
 
-    // '더 보기' 버튼 클릭 시 호출
+    // [수정] 로딩 중이 아닐 때만 다음 페이지 요청을 보냅니다.
     const handleLoadMore = () => {
+        if (fetchingMore) return;
         const nextPage = page + 1;
-        setPage(nextPage);
         fetchProjects(nextPage, true);
     };
 
@@ -137,31 +149,30 @@ export default function FreelancerExplorePage() {
                         MY_PROFILE
                     </button>
                     <div className="w-8 h-8 rounded-full bg-[#FF7D00] border-2 border-white shadow-sm overflow-hidden">
-                        <img src="https://placehold.co/100x100" alt="profile" />
+                        <img src="https://placehold.co/100x100" alt="profile" className="w-full h-full object-cover" />
                     </div>
                 </div>
             </nav>
 
             {/* Hero Section */}
-            <section className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden">
+            <header className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden text-center">
                 <div className="absolute inset-0 opacity-[0.03] pointer-events-none"
                      style={{ backgroundImage: 'linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)', backgroundSize: '40px 40px' }} />
-
-                <div className="absolute left-[-20px] bottom-4 opacity-10 hidden lg:block">
-                    <BarChart3 size={200} className="text-[#7A4FFF]" strokeWidth={0.5} />
+                <div className="absolute left-[-20px] bottom-4 opacity-5 hidden lg:block text-[#7A4FFF]">
+                    <BarChart3 size={200} strokeWidth={0.5} />
                 </div>
-                <div className="absolute right-[-40px] top-10 opacity-10 hidden lg:block rotate-12">
-                    <Activity size={240} className="text-[#FF7D00]" strokeWidth={0.5} />
+                <div className="absolute right-[-40px] top-10 opacity-5 hidden lg:block rotate-12 text-[#FF7D00]">
+                    <Activity size={240} strokeWidth={0.5} />
                 </div>
 
-                <div className="max-w-4xl mx-auto text-center relative z-10">
+                <div className="max-w-4xl mx-auto relative z-10">
                     <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
-                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4">
-                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾아보세요.
+                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4 text-zinc-900">
+                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾으세요.
                         </h1>
                         <div className="flex items-center justify-center gap-2 mb-10">
                             <span className="h-[1px] w-8 bg-zinc-200" />
-                            <p className="text-zinc-400 text-[10px] font-mono tracking-widest uppercase">
+                            <p className="text-zinc-400 text-[10px] font-mono tracking-[0.2em] uppercase">
                                 Available_Missions_Database_v2.0
                             </p>
                             <span className="h-[1px] w-8 bg-zinc-200" />
@@ -172,160 +183,154 @@ export default function FreelancerExplorePage() {
                         <Search className="absolute left-6 top-1/2 -translate-y-1/2 text-zinc-300 group-focus-within:text-[#7A4FFF] transition-colors" size={20} />
                         <input
                             type="text"
-                            placeholder="기술 스택, 프로젝트명 검색..."
+                            placeholder="기술 스택, 프로젝트명, 기업 검색..."
                             className="w-full bg-white border-2 border-zinc-200 rounded-full py-5 pl-16 pr-6 focus:ring-4 focus:ring-purple-500/5 focus:border-[#7A4FFF] outline-none transition-all font-bold text-sm shadow-xl shadow-purple-900/5"
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
                         />
                     </div>
                 </div>
-            </section>
+            </header>
 
-            <main className="max-w-5xl mx-auto px-6 mt-10">
-                <div className="flex flex-col md:flex-row items-center justify-between gap-6 mb-8">
-                    {/* 프로젝트 유형 탭 */}
-                    <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm overflow-x-auto no-scrollbar">
-                        {['전체', '온라인', '오프라인'].map((tab) => (
-                            <button
-                                key={tab}
-                                onClick={() => setActiveTab(tab)}
-                                className={`px-6 py-2 rounded-xl text-[11px] font-black transition-all whitespace-nowrap ${
-                                    activeTab === tab
-                                        ? 'bg-[#7A4FFF] text-white shadow-md'
-                                        : 'text-zinc-400 hover:text-zinc-900'
-                                }`}
-                            >
-                                {tab}
-                            </button>
-                        ))}
-                    </div>
+            <main className="max-w-6xl mx-auto px-6 md:px-10 py-10 flex flex-col lg:flex-row gap-10">
+                {/* 좌측 사이드바 필터 */}
+                <aside className="w-full lg:w-64 shrink-0 space-y-8">
+                    <section>
+                        <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm overflow-x-auto no-scrollbar">
+                            {['전체', '온라인', '오프라인'].map((tab) => (
+                                <button
+                                    key={tab}
+                                    onClick={() => setActiveTab(tab)}
+                                    className={`flex-1 py-2.5 rounded-xl text-[11px] font-black transition-all ${
+                                        activeTab === tab ? 'bg-zinc-900 text-white shadow-md' : 'text-zinc-400 hover:text-zinc-900'
+                                    }`}
+                                >
+                                    {tab}
+                                </button>
+                            ))}
+                        </div>
+                    </section>
 
-                    {/* 지역 필터 및 초기화 */}
-                    <div className="flex items-center gap-4 w-full md:w-auto overflow-hidden">
-                        <div className="flex gap-2 overflow-x-auto no-scrollbar py-1">
-                            {locations.map((loc) => (
+                    <section>
+                        <div className="flex items-center justify-between mb-4">
+                            <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase text-zinc-400 font-mono">
+                                <MapPin size={14} /> 활동_지역
+                            </h3>
+                            {selectedLocation && (
+                                <button onClick={() => setSelectedLocation('')} className="text-[10px] text-[#FF7D00] font-bold">초기화</button>
+                            )}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {locations.map(loc => (
                                 <button
                                     key={loc}
                                     onClick={() => setSelectedLocation(loc === selectedLocation ? '' : loc)}
-                                    className={`px-4 py-1.5 rounded-full text-[10px] font-bold border transition-all whitespace-nowrap ${
-                                        selectedLocation === loc
-                                            ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50 shadow-sm'
-                                            : 'border-zinc-200 text-zinc-500 bg-white hover:border-zinc-300'
+                                    className={`px-3 py-2 rounded-xl text-[11px] font-bold border transition-all ${
+                                        selectedLocation === loc ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50' : 'bg-white border-zinc-200 text-zinc-500 shadow-sm hover:border-zinc-300'
                                     }`}
                                 >
                                     {loc}
                                 </button>
                             ))}
                         </div>
+                    </section>
 
-                        {isFiltered && (
-                            <motion.button
-                                initial={{ opacity: 0, x: -10 }}
-                                animate={{ opacity: 1, x: 0 }}
-                                onClick={resetFilters}
-                                className="shrink-0 flex items-center gap-1.5 text-[10px] font-black text-zinc-400 hover:text-[#FF7D00] transition-colors uppercase font-mono group"
-                            >
-                                <RotateCcw size={12} className="group-hover:rotate-[-45deg] transition-transform" />
-                                Reset
-                            </motion.button>
-                        )}
-                    </div>
-                </div>
-
-                <div className="flex flex-col lg:flex-row gap-10">
-                    {/* 좌측 사이드바 필터 */}
-                    <aside className="w-full lg:w-64 shrink-0 space-y-8">
-                        <section>
-                            <h3 className="flex items-center gap-2 font-black text-xs tracking-widest uppercase mb-4 text-zinc-400 font-mono">
-                                <Cpu size={14} /> Tech_Stacks
-                            </h3>
-                            <div className="grid grid-cols-2 gap-2">
-                                {techStacks.map(tech => (
-                                    <button
-                                        key={tech}
-                                        // [수정] 다중 선택에서 단일 선택으로 변경 (토글 기능 유지)
-                                        onClick={() => setSelectedTech(selectedTech === tech ? '' : tech)}
-                                        className={`px-3 py-2 rounded-xl text-[10px] font-bold text-left transition-all border ${
-                                            selectedTech === tech
-                                                ? 'bg-zinc-900 border-zinc-900 text-white shadow-md'
-                                                : 'bg-white border-zinc-100 text-zinc-500 hover:border-zinc-300 shadow-sm'
-                                        }`}
-                                    >
-                                        {selectedTech === tech ? '● ' : '○ '} {tech}
-                                    </button>
-                                ))}
-                            </div>
-                        </section>
-
-                        <section>
-                            <h3 className="flex items-center gap-2 font-black text-xs tracking-widest uppercase mb-4 text-zinc-400 font-mono">
-                                <DollarSign size={14} /> Budget_Range
-                            </h3>
-                            <div className="p-4 bg-zinc-50 rounded-2xl border border-zinc-100 opacity-50 pointer-events-none">
-                                <input type="range" className="w-full accent-[#FF7D00]" min="0" max="2000" disabled />
-                                <div className="flex justify-between mt-2 font-mono text-[9px] text-zinc-400 font-bold">
-                                    <span>MIN</span>
-                                    <span>MAX</span>
-                                </div>
-                                <p className="text-[9px] text-center mt-2 text-zinc-400 font-bold">지원 준비 중</p>
-                            </div>
-                        </section>
-                    </aside>
-
-                    {/* 우측 공고 리스트 */}
-                    <section className="flex-1">
-                        <div className="flex justify-between items-end mb-6 border-b border-zinc-100 pb-4">
-                            <p className="font-mono text-[11px] font-black text-zinc-900 uppercase tracking-tighter">
-                                Total_Missions: <span className="text-[#FF7D00]">{totalElements}</span>
-                            </p>
-                            
-                            {/* [수정] 봇 리뷰 반영: 가짜 버튼 대신 실제 API와 연동되는 정렬(select) 도입 */}
-                            <div className="flex items-center gap-2 text-[10px] font-black uppercase font-mono text-zinc-400">
-                                SORT: 
-                                <select 
-                                    className="bg-transparent text-zinc-900 outline-none cursor-pointer hover:text-[#7A4FFF] transition-colors"
-                                    value={sort}
-                                    onChange={(e) => setSort(e.target.value)}
+                    <section>
+                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                            <Cpu size={14} /> 기술_스택
+                        </h3>
+                        <div className="grid grid-cols-2 gap-2">
+                            {techStacks.map(tech => (
+                                <button
+                                    key={tech}
+                                    onClick={() => setSelectedTech(selectedTech === tech ? '' : tech)}
+                                    className={`px-3 py-2.5 rounded-xl text-[10px] font-bold text-left transition-all border ${
+                                        selectedTech === tech ? 'bg-zinc-900 border-zinc-900 text-white shadow-md' : 'bg-white border-zinc-100 text-zinc-500 hover:border-zinc-300 shadow-sm'
+                                    }`}
                                 >
-                                    <option value="createdAt">LATEST (최신순)</option>
-                                    <option value="budget">BUDGET (예산순)</option>
-                                </select>
-                            </div>
-                        </div>
-
-                        <div className="grid grid-cols-1 gap-5">
-                            <AnimatePresence mode="popLayout">
-                                {projects.map((project, idx) => (
-                                    <ProjectCard key={project.projectId || project.id} data={project} index={idx} />
-                                ))}
-                            </AnimatePresence>
-
-                            {/* [수정] 봇 리뷰 반영: 무한 스크롤/페이지네이션 '더 보기' 버튼 추가 */}
-                            {hasMore && (
-                                <motion.button
-                                    initial={{ opacity: 0 }}
-                                    animate={{ opacity: 1 }}
-                                    onClick={handleLoadMore}
-                                    className="w-full py-4 mt-4 bg-white border border-zinc-200 rounded-2xl font-black text-[11px] text-zinc-500 uppercase tracking-widest font-mono hover:bg-zinc-50 hover:text-zinc-900 transition-all shadow-sm"
-                                >
-                                    Load_More_Missions
-                                </motion.button>
-                            )}
-
-                            {!loading && projects.length === 0 && (
-                                <div className="text-center py-28 bg-white rounded-[2.5rem] border border-dashed border-zinc-200 shadow-sm">
-                                    <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">No_Matching_Missions</h3>
-                                    <button
-                                        onClick={resetFilters}
-                                        className="px-8 py-3 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] transition-all shadow-xl active:scale-95"
-                                    >
-                                        RELOAD_SYSTEM
-                                    </button>
-                                </div>
-                            )}
+                                    {selectedTech === tech ? '● ' : '○ '} {tech}
+                                </button>
+                            ))}
                         </div>
                     </section>
-                </div>
+
+                    <section>
+                        <h3 className="flex items-center gap-2 font-black text-[10px] tracking-widest uppercase mb-4 text-zinc-400 font-mono">
+                            <DollarSign size={14} /> 희망_예산
+                        </h3>
+                        <div className="p-5 bg-white rounded-2xl border border-zinc-100 shadow-inner opacity-40">
+                            <input type="range" className="w-full accent-[#FF7D00]" disabled />
+                            <div className="flex justify-between mt-2 font-mono text-[9px] text-zinc-400 font-bold">
+                                <span>최소</span>
+                                <span>최대</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {isFiltered && (
+                        <button
+                            onClick={resetFilters}
+                            className="w-full flex items-center justify-center gap-2 py-4 bg-zinc-100 text-zinc-400 rounded-2xl text-[11px] font-black uppercase font-mono hover:bg-[#FF7D00] hover:text-white transition-all group shadow-sm"
+                        >
+                            <RotateCcw size={14} className="group-hover:rotate-[-45deg] transition-transform" />
+                            필터_설정_초기화
+                        </button>
+                    )}
+                </aside>
+
+                {/* 우측 공고 리스트 */}
+                <section className="flex-1">
+                    <div className="flex justify-between items-center mb-6 border-b border-zinc-100 pb-4">
+                        <p className="font-mono text-[11px] font-black text-zinc-900 uppercase tracking-tighter">
+                            Total_Missions: <span className="text-[#FF7D00] ml-1">{totalElements}</span>
+                        </p>
+                        
+                        <div className="flex items-center gap-2 text-[10px] font-black uppercase font-mono text-zinc-400">
+                            SORT: 
+                            <select 
+                                className="bg-transparent text-zinc-900 outline-none cursor-pointer hover:text-[#7A4FFF] transition-colors"
+                                value={sort}
+                                onChange={(e) => setSort(e.target.value)}
+                            >
+                                <option value="createdAt">LATEST (최신순)</option>
+                                <option value="budget">BUDGET (예산순)</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-5">
+                        <AnimatePresence mode="popLayout">
+                            {projects.map((project, idx) => (
+                                <ProjectCard key={project.projectId || project.id || idx} data={project} index={idx} />
+                            ))}
+                        </AnimatePresence>
+
+                        {hasMore && (
+                            <motion.button
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                onClick={handleLoadMore}
+                                disabled={fetchingMore}
+                                className="w-full py-4 mt-4 bg-white border border-zinc-200 rounded-2xl font-black text-[11px] text-zinc-500 uppercase tracking-widest font-mono hover:bg-zinc-50 hover:text-zinc-900 transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {fetchingMore ? "LOADING..." : "Load_More_Missions"}
+                            </motion.button>
+                        )}
+
+                        {!loading && projects.length === 0 && (
+                            <div className="text-center py-32 bg-white rounded-[2.5rem] border border-dashed border-zinc-200 shadow-sm">
+                                <Search className="w-12 h-12 text-zinc-200 mx-auto mb-6" />
+                                <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">일치하는_미션을_찾지_못함</h3>
+                                <button
+                                    onClick={resetFilters}
+                                    className="px-10 py-4 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] shadow-xl active:scale-95 transition-all"
+                                >
+                                    RELOAD_SYSTEM
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </section>
             </main>
         </div>
     );

--- a/frontend/app/freelancer/mainpage/page.tsx
+++ b/frontend/app/freelancer/mainpage/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Search, MapPin, Globe, RotateCcw, ChevronDown, BarChart3, Activity } from 'lucide-react';
+import ProjectCard from "@/components/freelancer/ProjectCard";
+import { useRouter } from 'next/navigation';
+import api from '@/app/lib/axios';
+
+export default function FreelancerExplorePage() {
+    const router = useRouter();
+    const [projects, setProjects] = useState<any[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [authorized, setAuthorized] = useState(false);
+
+    // 필터 상태 관리
+    const [searchQuery, setSearchQuery] = useState('');
+    const [selectedLocation, setSelectedLocation] = useState('전체');
+    const [activeTab, setActiveTab] = useState('전체');
+
+    const locations = ['인천', '서울', '경기', '부산', '대구', '원격'];
+
+    // [복구] 필터 초기화 로직
+    const resetFilters = () => {
+        setSearchQuery('');
+        setSelectedLocation('전체');
+        setActiveTab('전체');
+    };
+
+    useEffect(() => {
+        const checkAccess = async () => {
+            const token = localStorage.getItem("accessToken");
+            if (!token) {
+                alert("로그인이 필요합니다.");
+                router.replace("/login");
+                return;
+            }
+            try {
+                const res = await api.get("/v1/users/me");
+                const role = res.data.role;
+                if (role === "GUEST" || role === "ROLE_GUEST") {
+                    router.replace("/onboarding");
+                    return;
+                }
+                setAuthorized(true);
+            } catch (err) {
+                router.replace("/login");
+            }
+        };
+        checkAccess();
+    }, [router]);
+
+    const fetchProjects = async () => {
+        setLoading(true);
+        try {
+            const params = {
+                keyword: searchQuery || undefined,
+                location: selectedLocation === '전체' ? undefined : selectedLocation,
+            };
+            const { data } = await api.get('/v1/projects', { params });
+            setProjects(data.content || []);
+        } catch (err) {
+            console.error("프로젝트 공고를 불러오지 못했습니다.", err);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (authorized) {
+            const timeoutId = setTimeout(() => fetchProjects(), 300);
+            return () => clearTimeout(timeoutId);
+        }
+    }, [searchQuery, selectedLocation, authorized]);
+
+    if (!authorized) return <div className="min-h-screen bg-white flex items-center justify-center text-[#7A4FFF] font-black tracking-widest animate-pulse font-mono uppercase">System_Authorizing...</div>;
+
+    // 필터링 적용 여부 확인
+    const isFiltered = searchQuery !== '' || selectedLocation !== '전체' || activeTab !== '전체';
+
+    return (
+        <div className="min-h-screen bg-[#F9FAFB] text-zinc-900 pb-20 font-sans overflow-x-hidden">
+            {/* 상단 네비게이션 바 */}
+            <nav className="w-full py-5 px-10 bg-white/80 backdrop-blur-xl border-b border-zinc-200 flex justify-between items-center sticky top-0 z-50 shadow-sm">
+                <div className="font-black text-2xl tracking-tighter cursor-pointer" onClick={() => router.push("/")}>
+                    <span className="text-[#FF7D00]">Dev</span><span className="text-[#7A4FFF]">Near</span>
+                </div>
+                <div className="flex gap-6 items-center">
+                    <button onClick={() => router.push('/profile')} className="text-xs font-bold text-zinc-500 hover:text-zinc-900 tracking-widest transition uppercase font-mono">
+                        MY_PROFILE
+                    </button>
+                    <div className="w-8 h-8 rounded-full bg-[#FF7D00] border-2 border-white shadow-sm overflow-hidden">
+                        <img src="https://placehold.co/100x100" alt="profile" />
+                    </div>
+                </div>
+            </nav>
+
+            {/* [디자인 고도화] Hero Section with Blueprint Decorations */}
+            <section className="relative pt-24 pb-16 px-6 bg-white border-b border-zinc-100 overflow-hidden">
+                {/* 배경 데코레이션 1: 그리드 패턴 */}
+                <div className="absolute inset-0 opacity-[0.03] pointer-events-none"
+                     style={{ backgroundImage: 'linear-gradient(#000 1px, transparent 1px), linear-gradient(90deg, #000 1px, transparent 1px)', backgroundSize: '40px 40px' }} />
+
+                {/* 배경 데코레이션 2: 추상 그래프 (좌측 하단) */}
+                <div className="absolute left-[-20px] bottom-4 opacity-10 hidden lg:block">
+                    <BarChart3 size={200} className="text-[#7A4FFF]" strokeWidth={0.5} />
+                </div>
+
+                {/* 배경 데코레이션 3: 파동 그래프 (우측 상단) */}
+                <div className="absolute right-[-40px] top-10 opacity-10 hidden lg:block rotate-12">
+                    <Activity size={240} className="text-[#FF7D00]" strokeWidth={0.5} />
+                </div>
+
+                <div className="max-w-4xl mx-auto text-center relative z-10">
+                    <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }}>
+                        <h1 className="text-4xl md:text-5xl font-black tracking-tight mb-4">
+                            나에게 맞는 <span className="text-[#7A4FFF]">프로젝트</span>를 찾아보세요.
+                        </h1>
+                        <div className="flex items-center justify-center gap-2 mb-10">
+                            <span className="h-[1px] w-8 bg-zinc-200" />
+                            <p className="text-zinc-400 text-xs font-mono tracking-widest uppercase">
+                                Available_Missions_Database_v2.0
+                            </p>
+                            <span className="h-[1px] w-8 bg-zinc-200" />
+                        </div>
+                    </motion.div>
+
+                    <div className="max-w-2xl mx-auto relative group">
+                        <Search className="absolute left-6 top-1/2 -translate-y-1/2 text-zinc-300 group-focus-within:text-[#7A4FFF] transition-colors" size={20} />
+                        <input
+                            type="text"
+                            placeholder="기술 스택, 프로젝트명 검색..."
+                            className="w-full bg-white border border-zinc-200 rounded-full py-5 pl-16 pr-6 focus:ring-4 focus:ring-purple-500/5 focus:border-[#7A4FFF] outline-none transition-all font-bold text-sm shadow-xl shadow-purple-900/5"
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                        />
+                    </div>
+                </div>
+            </section>
+
+            {/* 필터 및 리스트 영역 */}
+            <main className="max-w-5xl mx-auto px-6 mt-10">
+                <div className="flex flex-col md:flex-row items-center justify-between gap-6 mb-8">
+                    {/* 프로젝트 유형 탭 */}
+                    <div className="flex bg-white p-1 rounded-2xl border border-zinc-200 shadow-sm overflow-x-auto no-scrollbar">
+                        {['전체', '온라인', '오프라인'].map((tab) => (
+                            <button
+                                key={tab}
+                                onClick={() => setActiveTab(tab)}
+                                className={`px-6 py-2 rounded-xl text-xs font-black transition-all whitespace-nowrap ${
+                                    activeTab === tab
+                                        ? 'bg-[#7A4FFF] text-white shadow-md'
+                                        : 'text-zinc-400 hover:text-zinc-900'
+                                }`}
+                            >
+                                {tab}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* 지역 필터 및 [복구] 초기화 버튼 */}
+                    <div className="flex items-center gap-4 w-full md:w-auto overflow-hidden">
+                        <div className="flex gap-2 overflow-x-auto no-scrollbar py-1">
+                            {locations.map((loc) => (
+                                <button
+                                    key={loc}
+                                    onClick={() => setSelectedLocation(loc === selectedLocation ? '전체' : loc)}
+                                    className={`px-4 py-1.5 rounded-full text-[11px] font-bold border transition-all whitespace-nowrap ${
+                                        selectedLocation === loc
+                                            ? 'border-[#7A4FFF] text-[#7A4FFF] bg-purple-50 shadow-sm'
+                                            : 'border-zinc-200 text-zinc-500 bg-white hover:border-zinc-300'
+                                    }`}
+                                >
+                                    {loc}
+                                </button>
+                            ))}
+                        </div>
+
+                        {/* 초기화 버튼 등장 */}
+                        {isFiltered && (
+                            <motion.button
+                                initial={{ opacity: 0, x: -10 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                onClick={resetFilters}
+                                className="shrink-0 flex items-center gap-1.5 text-[11px] font-black text-zinc-400 hover:text-[#FF7D00] transition-colors uppercase font-mono group"
+                            >
+                                <RotateCcw size={12} className="group-hover:rotate-[-45deg] transition-transform" />
+                                Reset
+                            </motion.button>
+                        )}
+                    </div>
+                </div>
+
+                {/* 리스트 본문 */}
+                <div className="space-y-4">
+                    <div className="flex justify-between items-center px-2 mb-2">
+                        <div className="flex items-center gap-2">
+                            <div className="w-2 h-2 rounded-full bg-[#7A4FFF] animate-pulse" />
+                            <p className="font-mono text-[10px] font-black text-zinc-500 uppercase tracking-widest">
+                                Active_Missions: <span className="text-[#FF7D00]">{projects.length}</span>
+                            </p>
+                        </div>
+                    </div>
+
+                    {loading ? (
+                        <div className="flex flex-col items-center justify-center py-24 gap-4">
+                            <div className="w-10 h-10 border-4 border-[#7A4FFF]/20 border-t-[#7A4FFF] rounded-full animate-spin"></div>
+                            <p className="text-[10px] font-mono font-black text-zinc-300 tracking-[0.2em] uppercase">Syncing_Dossier...</p>
+                        </div>
+                    ) : projects.length > 0 ? (
+                        <div className="grid grid-cols-1 gap-4">
+                            <AnimatePresence mode="popLayout">
+                                {projects.map((project, idx) => (
+                                    <ProjectCard key={project.projectId || project.id} data={project} index={idx} />
+                                ))}
+                            </AnimatePresence>
+                        </div>
+                    ) : (
+                        <div className="text-center py-28 bg-white rounded-[2.5rem] border border-dashed border-zinc-200">
+                            <h3 className="text-zinc-300 font-black text-xl font-mono uppercase tracking-tighter mb-6">No_Matching_Missions</h3>
+                            <button
+                                onClick={resetFilters}
+                                className="px-8 py-3 bg-zinc-950 text-white rounded-2xl font-black text-[11px] tracking-widest font-mono hover:bg-[#FF7D00] transition-all shadow-xl active:scale-95"
+                            >
+                                RELOAD_SYSTEM
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/components/freelancer/ProjectCard.tsx
+++ b/frontend/components/freelancer/ProjectCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Calendar, MapPin, ArrowUpRight, ShieldCheck } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 interface ProjectCardProps {
     data: any;
@@ -9,13 +10,20 @@ interface ProjectCardProps {
 }
 
 export default function ProjectCard({ data, index }: ProjectCardProps) {
-    // [보고] 백엔드의 ProjectResponse.java를 보면, ProjectSkill 엔티티를 
-    // List<String> skills = ["Java", "React"] 형태로 평탄화(Flatten)해서 보내줍니다!
-    // 따라서 data.projectSkills가 아니라 data.skills를 꺼내 쓰면 됩니다.
+    const router = useRouter();
     const skillList = data.skills || [];
+
+    // [수정] 카드 전체 영역 또는 버튼 클릭 시 상세 페이지로 라우팅
+    const handleViewMission = () => {
+        const id = data.projectId || data.id;
+        if (id) {
+            router.push(`/projects/${id}`);
+        }
+    };
 
     return (
         <motion.div
+            onClick={handleViewMission}
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ delay: index * 0.1 }}
@@ -59,7 +67,6 @@ export default function ProjectCard({ data, index }: ProjectCardProps) {
                                 </span>
                             ))
                         ) : (
-                            /* 데이터가 아예 없을 때 출력 (디버깅용) */
                             <span className="text-[10px] font-mono text-zinc-300 italic">No_Skills_Attached</span>
                         )}
                     </div>

--- a/frontend/components/freelancer/ProjectCard.tsx
+++ b/frontend/components/freelancer/ProjectCard.tsx
@@ -13,13 +13,30 @@ export default function ProjectCard({ data, index }: ProjectCardProps) {
     const router = useRouter();
     const skillList = data.skills || [];
 
-    // [수정] 카드 전체 영역 또는 버튼 클릭 시 상세 페이지로 라우팅
     const handleViewMission = () => {
         const id = data.projectId || data.id;
         if (id) {
             router.push(`/projects/${id}`);
         }
     };
+
+    // [수정] 봇 리뷰 반영: 백엔드 ProjectStatus Enum 값에 맞춘 동적 배지 스타일 및 텍스트 렌더링
+    const getStatusConfig = (status: string) => {
+        switch (status) {
+            case 'OPEN':
+                return { text: '모집중', classes: 'bg-dn-orange/10 text-dn-orange' };
+            case 'IN_PROGRESS':
+                return { text: '진행중', classes: 'bg-blue-50 text-blue-600' };
+            case 'COMPLETED':
+                return { text: '완료됨', classes: 'bg-green-50 text-green-600' };
+            case 'CLOSED':
+                return { text: '마감됨', classes: 'bg-zinc-100 text-zinc-500' };
+            default:
+                return { text: status || 'OPEN', classes: 'bg-dn-orange/10 text-dn-orange' };
+        }
+    };
+
+    const statusConfig = getStatusConfig(data.status);
 
     return (
         <motion.div
@@ -34,10 +51,8 @@ export default function ProjectCard({ data, index }: ProjectCardProps) {
                 {/* 좌측 정보 */}
                 <div className="flex-1">
                     <div className="flex items-center gap-3 mb-3">
-                        <span className={`px-3 py-1 rounded-full text-[10px] font-black uppercase font-mono tracking-tighter ${
-                            data.status === '긴급' ? 'bg-red-50 text-red-500' : 'bg-dn-orange/10 text-dn-orange'
-                        }`}>
-                            {data.status || 'OPEN'}
+                        <span className={`px-3 py-1 rounded-full text-[10px] font-black uppercase font-mono tracking-tighter ${statusConfig.classes}`}>
+                            {statusConfig.text}
                         </span>
                         <span className="text-zinc-300 font-mono text-[10px] tracking-widest">{data.createdAt || data.deadline}</span>
                     </div>

--- a/frontend/components/freelancer/ProjectCard.tsx
+++ b/frontend/components/freelancer/ProjectCard.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Calendar, MapPin, ArrowUpRight, ShieldCheck } from 'lucide-react';
+
+interface ProjectCardProps {
+    data: any;
+    index: number;
+}
+
+export default function ProjectCard({ data, index }: ProjectCardProps) {
+    // [보고] 백엔드의 ProjectResponse.java를 보면, ProjectSkill 엔티티를 
+    // List<String> skills = ["Java", "React"] 형태로 평탄화(Flatten)해서 보내줍니다!
+    // 따라서 data.projectSkills가 아니라 data.skills를 꺼내 쓰면 됩니다.
+    const skillList = data.skills || [];
+
+    return (
+        <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: index * 0.1 }}
+            whileHover={{ y: -4, boxShadow: '0 20px 25px -5px rgb(0 0 0 / 0.05)' }}
+            className="group bg-white border border-zinc-200 rounded-4xl p-6 transition-all cursor-pointer hover:border-dn-purple/30"
+        >
+            <div className="flex flex-col md:flex-row gap-6">
+                {/* 좌측 정보 */}
+                <div className="flex-1">
+                    <div className="flex items-center gap-3 mb-3">
+                        <span className={`px-3 py-1 rounded-full text-[10px] font-black uppercase font-mono tracking-tighter ${
+                            data.status === '긴급' ? 'bg-red-50 text-red-500' : 'bg-dn-orange/10 text-dn-orange'
+                        }`}>
+                            {data.status || 'OPEN'}
+                        </span>
+                        <span className="text-zinc-300 font-mono text-[10px] tracking-widest">{data.createdAt || data.deadline}</span>
+                    </div>
+
+                    <h2 className="text-xl font-black mb-2 group-hover:text-dn-purple transition-colors">{data.projectName || data.title}</h2>
+
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4">
+                        <div className="flex items-center gap-1 text-zinc-500 text-xs font-bold">
+                            <ShieldCheck size={14} className="text-dn-purple" /> {data.companyName || data.company || 'Private Client'}
+                        </div>
+                        <div className="flex items-center gap-1 text-zinc-400 text-xs font-mono font-bold">
+                            <MapPin size={14} /> {data.location || "Remote"}
+                        </div>
+                        <div className="flex items-center gap-1 text-zinc-400 text-xs font-mono font-bold">
+                            <Calendar size={14} /> ~ {data.deadline || data.period}
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                        {skillList.length > 0 ? (
+                            skillList.map((skillName: string, idx: number) => (
+                                <span
+                                    key={idx}
+                                    className="px-2.5 py-1 bg-zinc-50 border border-zinc-100 rounded-lg text-[10px] font-bold text-zinc-400 uppercase tracking-tighter font-mono group-hover:border-dn-purple/30 group-hover:text-zinc-600 transition-colors"
+                                >
+                                    #{skillName}
+                                </span>
+                            ))
+                        ) : (
+                            /* 데이터가 아예 없을 때 출력 (디버깅용) */
+                            <span className="text-[10px] font-mono text-zinc-300 italic">No_Skills_Attached</span>
+                        )}
+                    </div>
+                </div>
+
+                {/* 우측 금액 및 액션 */}
+                <div className="flex flex-col justify-between items-end md:w-48 border-t md:border-t-0 md:border-l border-zinc-100 pt-4 md:pt-0 md:pl-6">
+                    <div className="text-right">
+                        <p className="text-[10px] font-black text-zinc-400 uppercase font-mono tracking-widest mb-1">Estimated_Budget</p>
+                        <p className="text-2xl font-black text-zinc-900 font-mono tracking-tighter">
+                            <span className="text-dn-orange text-sm mr-1">₩</span>
+                            {((data.budget || 0) / 10000).toLocaleString()}만
+                        </p>
+                    </div>
+
+                    <motion.button
+                        whileTap={{ scale: 0.95 }}
+                        className="w-full mt-4 bg-zinc-900 text-white py-3 rounded-2xl font-black text-xs uppercase tracking-widest flex items-center justify-center gap-2 group-hover:bg-dn-purple transition-all"
+                    >
+                        VIEW_MISSION <ArrowUpRight size={14} />
+                    </motion.button>
+                </div>
+            </div>
+        </motion.div>
+    );
+}


### PR DESCRIPTION

## 🔎 What
- 지역(인천/서울 등) 및 프로젝트 유형(온라인/오프라인) 필터링 시스템 구축
- 필터 초기화(Reset) 기능 및 결과 부재 시 Empty State UI 추가
- ProjectCard 컴포넌트 내 백엔드 엔티티(ProjectSkill) 기반 기술 태그 렌더링 최적화

## 🔗 Issue

- Closes: #45 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project search expanded: supports /v1 route and filtering by keyword, location, skill, online/offline with newest-first paging.
  * Freelancer explore pages added with auth gating, debounced filtering, location chips, tabs (All/Online/Offline), sidebar filters, load-more, and reset control.
  * New animated, clickable project cards showing title, client, location, skills, status, deadline/period, and formatted budget.

* **Bug Fixes**
  * Prevented missing/empty skill lists so skills display reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->